### PR TITLE
fix: add missing TypeScript types

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "postcss": "8.4.31"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
     "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- add `@types/node` and `@types/react` dev dependencies so Next.js build doesn't try to auto-install them

## Testing
- `npm run build` *(fails: yarn add --exact --cwd /workspace/layscience/frontend --dev @types/react @types/node)*


------
https://chatgpt.com/codex/tasks/task_e_68a6a80a107c832b894f7e2b162dbdef