### PR TITLE
Fix backend imports and streamline UI

### DIFF
--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,0 +1,2 @@
+"""Backend source package."""
+

--- a/backend/src/common/__init__.py
+++ b/backend/src/common/__init__.py
@@ -1,0 +1,2 @@
+"""Common utilities and data models."""
+

--- a/backend/src/lambdas/__init__.py
+++ b/backend/src/lambdas/__init__.py
@@ -1,0 +1,2 @@
+"""Lambda function handlers."""
+

--- a/backend/src/steps/__init__.py
+++ b/backend/src/steps/__init__.py
@@ -1,0 +1,2 @@
+"""Pipeline step implementations."""
+

--- a/backend/tests/test_writer_shape.py
+++ b/backend/tests/test_writer_shape.py
@@ -1,3 +1,5 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from src.common.models import SummaryPayload
 
 def test_shape():

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,7 +3,7 @@ import { Toaster } from 'react-hot-toast'
 import ClientProviders from '@/components/ClientProviders';
 
 export const metadata = {
-  title: process.env.NEXT_PUBLIC_APP_NAME || 'LayScience (beta)',
+  title: process.env.NEXT_PUBLIC_APP_NAME || 'LayScience',
   description: 'Turn research papers into accurate lay summaries with evidence, in seconds.'
 }
 
@@ -14,19 +14,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="border-b border-border">
           <header className="container flex items-center justify-between py-4">
             <div className="text-2xl font-bold tracking-tight">
-              <span style={{color: '#00BFFF'}}>Lay</span>Science <span className="text-sm opacity-70">beta — AI may be wrong</span>
+              <span style={{color: '#00BFFF'}}>Lay</span>Science
             </div>
-            <nav className="text-sm opacity-80">
-              <a className="mr-4 hover:opacity-100" href="/">Home</a>
-              <a className="hover:opacity-100" href="#about">About</a>
-            </nav>
           </header>
         </div>
         <main className="container py-6">{children}</main>
         <footer className="container py-10 text-sm opacity-80">
-          <div className="border-t border-border pt-6 flex items-center justify-between">
-            <span>© {new Date().getFullYear()} LayScience</span>
-            <span>Accent <span style={{color:'#00BFFF'}}>#00BFFF</span> • Minimalist black UI</span>
+          <div className="border-t border-border pt-6 text-center">
+            © {new Date().getFullYear()} LayScience
           </div>
         </footer>
         <Toaster position="top-right" />

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -19,11 +19,6 @@ export default function Home() {
   const [status, setStatus] = useState<string|undefined>()
   const [progress, setProgress] = useState(15)
   const [summary, setSummary] = useState<any>(null)
-  const [readable, setReadable] = useState(false)
-
-  useEffect(()=>{
-    document.body.classList.toggle('readable', readable)
-  }, [readable])
 
   async function run() {
     const input:any = {}
@@ -66,8 +61,8 @@ export default function Home() {
       <section className="card relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none" style={{background:'radial-gradient(600px 200px at 80% -20%, rgba(0,191,255,.15), transparent), radial-gradient(400px 160px at 20% 0%, rgba(0,191,255,.08), transparent)'}} />
         <div className="relative">
-          <h1 className="text-4xl font-bold mb-2">Convert papers into clear, accurate lay summaries</h1>
-          <p className="opacity-80 mb-4">Paste a DOI/URL or upload a PDF. Choose 3‑sentence or 5‑paragraph. Every claim links to evidence.</p>
+          <h1 className="text-4xl font-bold mb-2">Summarize research papers</h1>
+          <p className="opacity-80 mb-4">Paste a DOI/URL or upload a PDF.</p>
           <div className="grid sm:grid-cols-2 gap-3">
             <input className="input" placeholder="DOI e.g., 10.xxxx/xxxxx" value={doi} onChange={e=>setDoi(e.target.value)} />
             <input className="input" placeholder="Paper URL e.g., https://..." value={url} onChange={e=>setUrl(e.target.value)} />
@@ -90,28 +85,7 @@ export default function Home() {
         <PrivacySelect value={privacy} onChange={setPrivacy} />
       </div>
 
-      <section className="card" id="about">
-        <div className="grid sm:grid-cols-3 gap-4">
-          <div>
-            <div className="font-semibold mb-1">Evidence‑grounded</div>
-            <div className="small">Every sentence cites supporting text from the paper; the model can’t invent numbers.</div>
-          </div>
-          <div>
-            <div className="font-semibold mb-1">Accessibility & TTS</div>
-            <div className="small">Large text, readability font, keyboard nav, and a one‑click audio narration.</div>
-          </div>
-          <div>
-            <div className="font-semibold mb-1">Privacy modes</div>
-            <div className="small">Process‑only leaves no trace; Private keeps a copy; Public creates a shareable link.</div>
-          </div>
-        </div>
-        <div className="mt-3 small opacity-70">
-          (beta) This is a test version; AI can make mistakes. Verify with the original paper.
-        </div>
-        <div className="mt-3">
-          <label className="small"><input type="checkbox" checked={readable} onChange={()=>setReadable(!readable)} /> Readability font & spacing</label>
-        </div>
-      </section>
+      
 
       {summary && (
         <section>


### PR DESCRIPTION
## Summary
- add package initializers so backend modules can be imported
- simplify frontend layout to a minimalist header/footer
- remove extra text from the home page

## Testing
- `pytest backend/tests/test_writer_shape.py -q`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac323cc0832bb7604374dc7bb2ab