### PR TITLE
fix: respect API base env var in frontend

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,7 +3,11 @@ export type StartPayload = {
   mode: 'micro' | 'extended';
   privacy: 'process-only' | 'private' | 'public';
 }
-export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_BASE_URL
+if (!apiBase) {
+  throw new Error('API base URL not configured')
+}
+export const API_BASE = apiBase
 
 async function ok(res: Response) {
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- read API base URL from `NEXT_PUBLIC_API_BASE` with fallback to `NEXT_PUBLIC_API_BASE_URL`
- throw explicit error when API base is missing to avoid mysterious job start failures

## Testing
- `pytest -q`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6afcece34832b8dcb3ed51ad018ae