### PR TITLE
Handle missing API base at runtime

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,11 +3,15 @@ export type StartPayload = {
   mode: 'micro' | 'extended';
   privacy: 'process-only' | 'private' | 'public';
 }
-const apiBase = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_BASE_URL
-if (!apiBase) {
-  throw new Error('API base URL not configured')
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_BASE_URL
+
+function requireApiBase(): string {
+  if (!API_BASE) {
+    throw new Error('API base URL not configured')
+  }
+  return API_BASE
 }
-export const API_BASE = apiBase
 
 async function ok(res: Response) {
   if (!res.ok) {
@@ -18,26 +22,45 @@ async function ok(res: Response) {
 }
 
 export async function getUploadUrl() {
-  const r = await fetch(`${API_BASE}/upload-url`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ content_type: 'application/pdf' }) })
+  const base = requireApiBase()
+  const r = await fetch(`${base}/upload-url`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ content_type: 'application/pdf' })
+  })
   return ok(r) as Promise<{ key: string, url: string }>
 }
 
 export async function startJob(payload: StartPayload) {
-  const r = await fetch(`${API_BASE}/summaries`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) })
+  const base = requireApiBase()
+  const r = await fetch(`${base}/summaries`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
   return ok(r) as Promise<{ id: string, status: string }>
 }
 
 export async function getStatus(id: string) {
-  const r = await fetch(`${API_BASE}/summaries/status?id=${encodeURIComponent(id)}`)
+  const base = requireApiBase()
+  const r = await fetch(
+    `${base}/summaries/status?id=${encodeURIComponent(id)}`
+  )
   return ok(r) as Promise<{ id: string, status: string }>
 }
 
 export async function getSummary(id: string) {
-  const r = await fetch(`${API_BASE}/summaries/${id}`)
+  const base = requireApiBase()
+  const r = await fetch(`${base}/summaries/${id}`)
   return ok(r)
 }
 
 export async function translateSummary(id: string, target: string) {
-  const r = await fetch(`${API_BASE}/summaries/${id}/translate`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ target_language: target }) })
+  const base = requireApiBase()
+  const r = await fetch(`${base}/summaries/${id}/translate`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ target_language: target })
+  })
   return ok(r)
 }


### PR DESCRIPTION
## Summary
- avoid throwing during module import when API base is undefined
- ensure API base is checked only when API functions are invoked

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b7f9845c832b8f02beb996cdb18a