### PR TITLE
fix: normalize API base path

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,8 +1,9 @@
-const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000";
+const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
 
 function api(path: string) {
-  if (typeof window !== "undefined") return `/api/proxy${path}`;
-  return `${BASE}${path}`;
+  const p = path.startsWith("/") ? path : `/${path}`;
+  if (typeof window !== "undefined") return `/api/proxy${p}`;
+  return `${BASE}${p}`;
 }
 
 async function asJson(res: Response) {


### PR DESCRIPTION
## Summary
- ensure API paths have leading slash and use 127.0.0.1 default base to avoid 404s

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a74ca2be84832b9b77e367b6e00d86