### PR TITLE
fix: align frontend API with backend

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -17,18 +17,22 @@ async function asJson(res: Response) {
   return isJson ? res.json() : res.text();
 }
 
-export async function uploadFile(file: File): Promise<{file_id: string}> {
+export async function startJob({
+  ref,
+  file,
+  length
+}: {
+  ref?: string;
+  file?: File | null;
+  length?: "default" | "extended";
+}) {
   const form = new FormData();
-  form.append("file", file);
-  const res = await fetch(api("/api/v1/upload"), { method: "POST", body: form });
-  return asJson(res);
-}
-
-export async function startJob(input: { doi?: string; url?: string; file_id?: string }) {
-  const res = await fetch(api("/api/v1/jobs"), {
+  if (ref) form.append("ref", ref);
+  if (length) form.append("length", length);
+  if (file) form.append("pdf", file);
+  const res = await fetch(api("/api/v1/summaries"), {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ input, mode: "micro", privacy: "private" })
+    body: form
   });
   return asJson(res);
 }


### PR DESCRIPTION
## Summary
- align frontend `startJob` helper with backend summarization endpoint
- support sending DOI/URL, PDF, and length in one request

## Testing
- `npm --prefix frontend run lint` *(fails: prompts for ESLint setup)*
- `pip install -r backend/requirements.txt` *(fails: could not fetch beautifulsoup4 due to proxy restrictions)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a3ade3b8832bb383b925a60f373a