### PR TITLE
Fix job result storage and health check

### DIFF
--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -110,8 +110,8 @@ def _normalize_ref(ref: Optional[str], doi: Optional[str], url: Optional[str]) -
 # Health endpoints ------------------------------------------------------------
 @app.get("/healthz")
 def healthz():
-    ok, msg = jobs_store.healthcheck()
-    return {"ok": ok, "db": msg, "time": datetime.utcnow().isoformat() + "Z"}
+    status = jobs_store.health()
+    return {"ok": status.get("ok", False), "db": status.get("db_path"), "time": datetime.utcnow().isoformat() + "Z"}
 
 @app.get("/api/v1/version")
 def version():


### PR DESCRIPTION
## Summary
- ensure job results are JSON encoded/decoded when updating or fetching jobs
- correct `/healthz` endpoint to use the new `jobs_store.health()` function

## Testing
- `python -m py_compile backend/server/main.py backend/server/services/jobs.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87d3fb010832bb7df515e0ddeeb60