### PR TITLE
feat: require api base env var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,6 +3,16 @@
 
 Next.js 14 app that talks to the backend through an **edge proxy** at `/api/proxy/...`.
 
+## Environment variables
+
+Only the backend needs the OpenAI credentials. The frontend requires a single variable:
+
+| Name | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_API_BASE` | Base URL of the backend API. Must be set in production deployments. |
+
+If `NEXT_PUBLIC_API_BASE` is missing in production, the proxy route will respond with a helpful error instead of silently falling back to `127.0.0.1`.
+
 ## Local dev
 
 ```bash

--- a/frontend/app/api/proxy/[...path]/route.ts
+++ b/frontend/app/api/proxy/[...path]/route.ts
@@ -1,5 +1,8 @@
 // app/api/proxy/[...path]/route.ts
-const RAW_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
+const DEFAULT_BASE = "http://127.0.0.1:8000";
+const RAW_BASE =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  (process.env.NODE_ENV === "development" ? DEFAULT_BASE : "");
 
 function joinUrl(base: string, path: string) {
   const b = new URL(base);
@@ -34,6 +37,23 @@ async function forwardOnce(req: Request, base: string, segments: string[], buf?:
 }
 
 async function handle(req: Request, { params }: { params: { path?: string[] } }) {
+  if (!RAW_BASE) {
+    return new Response(
+      JSON.stringify(
+        {
+          error: "NEXT_PUBLIC_API_BASE is not set",
+          hint: "Set NEXT_PUBLIC_API_BASE to your backend URL"
+        },
+        null,
+        2
+      ),
+      {
+        status: 500,
+        headers: { "content-type": "application/json" }
+      }
+    );
+  }
+
   const segments = params.path || [];
   let buf: ArrayBuffer | undefined;
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,8 +1,12 @@
-const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
+const DEFAULT_BASE = "http://127.0.0.1:8000";
+const BASE =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  (process.env.NODE_ENV === "development" ? DEFAULT_BASE : "");
 
 function api(path: string) {
   const p = path.startsWith("/") ? path : `/${path}`;
   if (typeof window !== "undefined") return `/api/proxy${p}`;
+  if (!BASE) throw new Error("NEXT_PUBLIC_API_BASE is not set");
   return `${BASE}${p}`;
 }
 


### PR DESCRIPTION
## Summary
- check for NEXT_PUBLIC_API_BASE in proxy route and API helper
- document frontend env var requirements

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font `Bebas Neue`)*

------
https://chatgpt.com/codex/tasks/task_e_68a88eb8215c832b8b79692c2355e545