### PR TITLE
Add root-level aliases to fix backend 404s

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,12 +4,12 @@
 This backend provides a robust FastAPI service that accepts a DOI/URL **and/or** a PDF and returns a lay summary using **OpenAI GPT‑5** via the **Responses API**. It fixes:
 
 - **HTTP 500: `attempt to write a readonly database`** — now the DB path is configurable and defaults to a writable directory. The `/healthz` endpoint tells you if the DB is writable.
-- **HTTP 404: `Not Found` when pressing “summarise”** — we ship multiple route aliases (`/api/v1/summaries`, `/api/v1/summarize`, `/api/v1/summarise`) to prevent path mismatches.
+- **HTTP 404: `Not Found` when pressing “summarise”** — we ship multiple route aliases (`/api/v1/summaries`, `/api/v1/summarize`, `/api/v1/summarise`, `/summaries`, `/summarize`, `/summarise`) to prevent path mismatches.
 - **State-of-the-art debugging** — every response includes an **`X-Request-ID`**; errors return structured JSON with `error`, `message`, `hint`, `where`, and `correlation_id`.
 
 ## Endpoints
 
-- `POST /api/v1/summaries` (aliases `/api/v1/summarize`, `/api/v1/summarise`)
+- `POST /api/v1/summaries` (aliases `/api/v1/summarize`, `/api/v1/summarise`, `/summaries`, `/summarize`, `/summarise`)
   - Content types:
     - **JSON:** `{ "ref": "<doi or url>", "length": "default|extended" }`
     - **multipart/form-data:** fields `ref|doi|url` (optional), `pdf` (optional), `length` (`default`|`extended`)
@@ -116,7 +116,7 @@ In your own code, prefer pinning to a dated snapshot for reproducibility.
 ## Troubleshooting
 
 - **500 `attempt to write a readonly database`**: Your SQLite file or parent directory isn’t writable. Fix by setting `JOBS_DB_PATH` to a writable location or mount a disk. Check `/healthz` output.
-- **404 `Not Found` when clicking “summarise”**: The frontend previously called a different route. We now expose `/api/v1/summaries` **and** legacy aliases (`/api/v1/summarize`, `/api/v1/summarise`). Ensure the frontend points to one of these.
+- **404 `Not Found` when clicking “summarise”**: The frontend previously called a different route. We now expose `/api/v1/summaries` **and** legacy aliases (`/api/v1/summarize`, `/api/v1/summarise`, `/summaries`, `/summarize`, `/summarise`). Ensure the frontend points to one of these.
 - **CORS errors**: Set `ALLOWED_ORIGINS` to your frontend origin (comma-separated if multiple).
 - **OpenAI auth**: Ensure `OPENAI_API_KEY` is set in the backend environment.
 - **Long PDFs**: The server truncates extracted text to `MAX_SOURCE_CHARS` (default 120k). Override if needed.

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -121,6 +121,10 @@ def version():
 @app.post("/api/v1/summarize")
 @app.post("/api/v1/summarise")  # UK spelling
 @app.post("/api/v1/summaries")
+# Root-level aliases for older frontends
+@app.post("/summarize")
+@app.post("/summarise")
+@app.post("/summaries")
 async def start_summary(
     background: BackgroundTasks,
     request: Request,
@@ -240,6 +244,7 @@ async def process_job(job_id: str, request_id: str):
 
 # Job polling endpoints ------------------------------------------------------
 @app.get("/api/v1/jobs/{job_id}")
+@app.get("/jobs/{job_id}")
 def get_job(job_id: str):
     j = jobs_store.get(job_id)
     if not j:
@@ -247,6 +252,7 @@ def get_job(job_id: str):
     return {"id": job_id, "status": j["status"], "payload": j.get("payload"), "error": j.get("error")}
 
 @app.get("/api/v1/summaries/{job_id}")
+@app.get("/summaries/{job_id}")
 def get_summary(job_id: str):
     j = jobs_store.get(job_id)
     if not j:


### PR DESCRIPTION
## Summary
- expose `/summaries`, `/summarize`, and `/summarise` aliases alongside `/api/v1/*` routes
- document new paths in backend README for easier integration

## Testing
- `pytest backend/tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89e5a2374832b839c0157fd94d114