### PR TITLE
Use American English in interface

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,12 +4,12 @@
 This backend provides a robust FastAPI service that accepts a DOI/URL **and/or** a PDF and returns a lay summary using **OpenAI GPT‑5** via the **Responses API**. It fixes:
 
 - **HTTP 500: `attempt to write a readonly database`** — now the DB path is configurable and defaults to a writable directory. The `/healthz` endpoint tells you if the DB is writable.
-- **HTTP 404: `Not Found` when pressing “summarise”** — we ship multiple route aliases (`/api/v1/summaries`, `/api/v1/summarize`, `/api/v1/summarise`) to prevent path mismatches.
+- **HTTP 404: `Not Found` when pressing “Summarize”** — we ship multiple route aliases (`/api/v1/summaries`, `/api/v1/summarize`, legacy `/api/v1/summarise`) to prevent path mismatches.
 - **State-of-the-art debugging** — every response includes an **`X-Request-ID`**; errors return structured JSON with `error`, `message`, `hint`, `where`, and `correlation_id`.
 
 ## Endpoints
 
-- `POST /api/v1/summaries` (aliases `/api/v1/summarize`, `/api/v1/summarise`)
+- `POST /api/v1/summaries` (aliases `/api/v1/summarize`, legacy `/api/v1/summarise`)
   - Content types:
     - **JSON:** `{ "ref": "<doi or url>", "length": "default|extended" }`
     - **multipart/form-data:** fields `ref|doi|url` (optional), `pdf` (optional), `length` (`default`|`extended`)
@@ -116,7 +116,7 @@ In your own code, prefer pinning to a dated snapshot for reproducibility.
 ## Troubleshooting
 
 - **500 `attempt to write a readonly database`**: Your SQLite file or parent directory isn’t writable. Fix by setting `JOBS_DB_PATH` to a writable location or mount a disk. Check `/healthz` output.
-- **404 `Not Found` when clicking “summarise”**: The frontend previously called a different route. We now expose `/api/v1/summaries` **and** legacy aliases (`/api/v1/summarize`, `/api/v1/summarise`). Ensure the frontend points to one of these.
+- **404 `Not Found` when clicking “Summarize”**: The frontend previously called a different route. We now expose `/api/v1/summaries` and legacy aliases (`/api/v1/summarize`, legacy `/api/v1/summarise`). Ensure the frontend points to one of these.
 - **CORS errors**: Set `ALLOWED_ORIGINS` to your frontend origin (comma-separated if multiple).
 - **OpenAI auth**: Ensure `OPENAI_API_KEY` is set in the backend environment.
 - **Long PDFs**: The server truncates extracted text to `MAX_SOURCE_CHARS` (default 120k). Override if needed.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,7 +29,7 @@ If you see a 404 or CORS error, verify:
 
 - The backend is running at `NEXT_PUBLIC_API_BASE`.
 - Backend `ALLOWED_ORIGINS` includes `http://localhost:3000`.
-- The proxy path matches backend (we support `/api/v1/summaries`, `/summarize`, `/summarise`).
+- The proxy path matches backend (`/api/v1/summaries` or `/summarize`; a legacy `/summarise` alias also exists).
 
 ## Deploy
 

--- a/frontend/__tests__/home.test.tsx
+++ b/frontend/__tests__/home.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import Home from '../app/page';
 
 describe('Home', () => {
-  it('renders Summrise button', () => {
+  it('renders Summarize button', () => {
     render(<Home />);
-    expect(screen.getByRole('button', { name: /summrise/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /summarize/i })).toBeInTheDocument();
   });
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -89,7 +89,7 @@ export default function Home() {
               onClick={onStart}
               disabled={busy}
             >
-              Summrise
+              Summarize
             </button>
           </div>
           {file && <p className="mt-2 text-xs text-neutral-400">Selected: {file.name}</p>}


### PR DESCRIPTION
## Summary
- Replace typoed British spelling with American "Summarize" button text.
- Update tests and docs to prefer American English and mark `/summarise` as a legacy alias.

## Testing
- `npm test` *(fails: jest not found and installation blocked by 403)*
- `pytest -q backend/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a89fa8132c832b81505893ac881625