### PR TITLE
Fix missing multipart dependency and logging error

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4>=4.12,<5.0
 pypdf>=3.17,<4.0
 openai>=1.12,<2.0
 python-dotenv>=1.0,<2.0  # optional: load .env variables
+python-multipart>=0.0.5,<0.1  # required for form-data parsing

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -48,7 +48,12 @@ class RequestIdFilter(logging.Filter):
         return True
 
 
-logger.addFilter(RequestIdFilter())
+# Apply the filter to our logger, root logger and uvicorn's loggers so that
+# log records without a ``request_id`` don't cause formatting errors.
+_request_id_filter = RequestIdFilter()
+logger.addFilter(_request_id_filter)
+logging.getLogger().addFilter(_request_id_filter)
+logging.getLogger("uvicorn").addFilter(_request_id_filter)
 
 # FastAPI app
 app = FastAPI(title="LayScience Summariser API", version="1.0.0")


### PR DESCRIPTION
## Summary
- include python-multipart dependency for FastAPI form parsing
- guard logging format against missing request_id across all loggers

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement pypdf<4.0,>=3.17)*
- `pytest` *(fails: test_start_summary_missing_input, test_pdf_upload_summary, test_ref_summary)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bc4b18dc832b92799d595412fb79