### PR TITLE
fix: accept json summary requests

### DIFF
--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -19,7 +19,7 @@ from typing import Optional, Dict, Any
 from datetime import datetime
 from typing import Literal
 
-from fastapi import FastAPI, HTTPException, UploadFile, File, Form, BackgroundTasks, Request
+from fastapi import FastAPI, HTTPException, UploadFile, BackgroundTasks, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -150,12 +150,6 @@ def version():
 async def start_summary(
     background: BackgroundTasks,
     request: Request,
-    ref: Optional[str] = Form(default=None),
-    doi: Optional[str] = Form(default=None),
-    url: Optional[str] = Form(default=None),
-    length: str = Form(default="default"),
-    pdf: Optional[UploadFile] = File(default=None),
-    body: Optional[StartJobJSON] = None,
 ):
     """
     Start a summarisation job.
@@ -167,12 +161,24 @@ async def start_summary(
     """
     rid = getattr(request.state, "request_id", "-")
 
-    # If JSON body provided and no form fields, use body
-    if body and not (ref or doi or url or pdf):
+    content_type = request.headers.get("content-type", "")
+    ref = doi = url = None
+    length = "default"
+    pdf: Optional[UploadFile] = None
+
+    if content_type.startswith("application/json"):
+        data = await request.json()
+        body = StartJobJSON.model_validate(data)
         ref = body.ref
         length = body.length or length
+    else:
+        form = await request.form()
+        ref = form.get("ref")
+        doi = form.get("doi")
+        url = form.get("url")
+        length = form.get("length", length)
+        pdf = form.get("pdf")  # may be UploadFile or None
 
-    # Validate at least one input
     ref_value = _normalize_ref(ref, doi, url)
     if not ref_value and not pdf:
         raise err.BadRequest(
@@ -188,10 +194,15 @@ async def start_summary(
             where="start_summary",
         )
 
-    # Save uploaded PDF if provided
     saved_pdf_path: Optional[str] = None
     saved_pdf_name: Optional[str] = None
     if pdf is not None:
+        if not hasattr(pdf, "filename"):
+            raise err.BadRequest(
+                "invalid_file",
+                "Expected file upload for 'pdf'.",
+                where="start_summary",
+            )
         if not pdf.filename:
             raise err.BadRequest(
                 "invalid_file",
@@ -199,7 +210,6 @@ async def start_summary(
                 where="start_summary",
             )
         if not pdf.content_type or "pdf" not in pdf.content_type.lower():
-            # allow unknown type but enforce .pdf extension if present
             if not str(pdf.filename).lower().endswith(".pdf"):
                 raise err.BadRequest(
                     "invalid_file_type",

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -17,7 +17,7 @@ client = TestClient(main.app)
 
 
 def test_start_summary_missing_input():
-    resp = client.post('/api/v1/summarize', data={})
+    resp = client.post('/api/v1/summaries', json={})
     assert resp.status_code == 400
     body = resp.json()
     assert body['error'] == 'missing_input'
@@ -28,7 +28,7 @@ def test_pdf_upload_summary(monkeypatch):
         return 'PDF content about biology.', {'title': 'Bio Paper', 'authors': 'A'}
     monkeypatch.setattr(pdfio, 'extract_text_and_meta', fake_extract)
     files = {'pdf': ('paper.pdf', b'fake', 'application/pdf')}
-    resp = client.post('/api/v1/summarize', files=files)
+    resp = client.post('/api/v1/summaries', files=files)
     assert resp.status_code == 200
     job_id = resp.json()['id']
     for _ in range(20):
@@ -45,7 +45,7 @@ def test_ref_summary(monkeypatch):
     def fake_fetch(ref: str):
         return 'Text from web about physics.', {'title': 'Phys Paper', 'authors': 'B'}
     monkeypatch.setattr(fetcher, 'fetch_and_extract', fake_fetch)
-    resp = client.post('/api/v1/summarize', data={'ref': 'https://example.com/paper'})
+    resp = client.post('/api/v1/summaries', json={'ref': 'https://example.com/paper'})
     assert resp.status_code == 200
     job_id = resp.json()['id']
     for _ in range(20):


### PR DESCRIPTION
## Summary
- allow /summaries endpoint to parse JSON or multipart form uploads
- adjust API tests to use canonical `/api/v1/summaries` route and cover JSON input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc80803c832bb2a5fa66c61a226a