### PR TITLE
Improve responsiveness across devices

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import ClientToaster from "@/components/ClientToaster";
 import { Bebas_Neue, Inter } from "next/font/google";
 
@@ -8,7 +8,12 @@ const body = Inter({ subsets: ["latin"], variable: "--font-body" });
 
 export const metadata: Metadata = {
   title: "Lay Science",
-  description: "AI that turns research into clear, engaging summaries."
+  description: "AI that turns research into clear, engaging summaries.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -60,41 +60,43 @@ export default function Home() {
 
   return (
     <main className="min-h-dvh flex flex-col bg-neutral-950 text-neutral-100">
-      <section className="flex-1 flex flex-col items-center justify-center px-6 text-center">
-        <h1 className="font-heading text-5xl mb-2">Lay Science</h1>
-        <p className="text-neutral-400 mb-8">AI that turns research into clear, engaging summaries.</p>
-        <div className="w-full max-w-xl">
-          <div className="flex items-center gap-2 rounded-full border border-neutral-700 bg-neutral-900/60 px-4 py-3 focus-within:ring-2 focus-within:ring-white/30">
-            <label className="cursor-pointer text-neutral-400 hover:text-white">
-              <input
-                type="file"
-                accept="application/pdf"
-                className="hidden"
-                onChange={(e) => setFile(e.target.files?.[0] || null)}
-              />
-              <svg viewBox="0 0 24 24" fill="none" className="h-5 w-5">
-                <path stroke="currentColor" strokeWidth="1.5" d="M12 4.5v15m7.5-7.5h-15" />
-              </svg>
-            </label>
-            <input
-              className="flex-1 bg-transparent text-neutral-200 placeholder:text-neutral-500 outline-none"
-              placeholder="Upload a paper or enter a DOI/URL"
-              value={ref}
-              onChange={(e) => setRef(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') onStart(); }}
-            />
-            <button
-              type="button"
-              className="text-neutral-400 hover:text-white disabled:opacity-50"
-              onClick={onStart}
-              disabled={busy}
-            >
-              Summarize
-            </button>
+        <section className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+          <h1 className="font-heading text-4xl sm:text-5xl mb-2">Lay Science</h1>
+          <p className="text-neutral-400 mb-8 text-sm sm:text-base">AI that turns research into clear, engaging summaries.</p>
+          <div className="w-full max-w-xl">
+            <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 rounded-2xl sm:rounded-full border border-neutral-700 bg-neutral-900/60 px-4 py-3 focus-within:ring-2 focus-within:ring-white/30">
+              <div className="flex items-center gap-2 flex-1">
+                <label className="cursor-pointer text-neutral-400 hover:text-white">
+                  <input
+                    type="file"
+                    accept="application/pdf"
+                    className="hidden"
+                    onChange={(e) => setFile(e.target.files?.[0] || null)}
+                  />
+                  <svg viewBox="0 0 24 24" fill="none" className="h-5 w-5">
+                    <path stroke="currentColor" strokeWidth="1.5" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                </label>
+                <input
+                  className="flex-1 bg-transparent text-neutral-200 placeholder:text-neutral-500 outline-none"
+                  placeholder="Upload a paper or enter a DOI/URL"
+                  value={ref}
+                  onChange={(e) => setRef(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') onStart(); }}
+                />
+              </div>
+              <button
+                type="button"
+                className="text-neutral-400 hover:text-white disabled:opacity-50 w-full sm:w-auto"
+                onClick={onStart}
+                disabled={busy}
+              >
+                Summarize
+              </button>
+            </div>
+            {file && <p className="mt-2 text-xs text-neutral-400">Selected: {file.name}</p>}
           </div>
-          {file && <p className="mt-2 text-xs text-neutral-400">Selected: {file.name}</p>}
-        </div>
-      </section>
+        </section>
 
       <section className="mx-auto w-full max-w-3xl px-6 pb-16">
         {summary ? (


### PR DESCRIPTION
## Summary
- add viewport metadata for proper mobile scaling
- adjust landing page form and typography for smaller and larger screens

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - @testing-library/jest-dom)*
- `pytest` *(fails: assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e14dd7e4832b8aaa2d61e681c530