### PR TITLE
Fix TypeError when joining candidate PDF URLs

### DIFF
--- a/backend/server/services/fetcher.py
+++ b/backend/server/services/fetcher.py
@@ -91,7 +91,6 @@ def fetch_and_extract(ref: str) -> Tuple[str, Dict[str, Any]]:
             # Otherwise parse HTML
             html = r.text
             soup = BeautifulSoup(html, "html.parser")
-            base_url = final_url
 
             # Collect candidate PDF links from meta/link/a tags
             candidates: List[str] = []
@@ -135,7 +134,7 @@ def fetch_and_extract(ref: str) -> Tuple[str, Dict[str, Any]]:
 
             # Try candidate PDFs
             for href in cleaned:
-                pdf_url = urljoin(base_url, href)  # both args are str
+                pdf_url = urljoin(str(r.url), href)
                 try:
                     pr = client.get(pdf_url)
                     if pr.status_code == 200 and "pdf" in (pr.headers.get("content-type", "").lower()):


### PR DESCRIPTION
## Summary
- ensure candidate PDF URLs use `urljoin(str(r.url), href)` so both inputs are strings

## Testing
- `python - <<'PY'
import os, threading, http.server, socketserver, time
from backend.server.services import fetcher

root = '/tmp/tmpj68ayyk_'
PORT = 8000

class Handler(http.server.SimpleHTTPRequestHandler):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, directory=root, **kwargs)

httpd = socketserver.TCPServer(('', PORT), Handler)
thread = threading.Thread(target=httpd.serve_forever)
thread.daemon = True
thread.start()

# allow server to start
import time
for _ in range(10):
    if httpd.server_address:
        break
    time.sleep(0.1)

# patch extract_text_and_meta
orig = fetcher.extract_text_and_meta
fetcher.extract_text_and_meta = lambda path: ('PDF text', {'dummy': True})

try:
    text, meta = fetcher.fetch_and_extract(f'http://localhost:{PORT}/index.html')
    print('RESULT', text, meta)
finally:
    fetcher.extract_text_and_meta = orig
    httpd.shutdown()
    thread.join()
PY`
- `pytest -q` *(fails: The `python-multipart` library must be installed to use form parsing.)*
- `pip install python-multipart` *(fails: Could not find a version that satisfies the requirement python-multipart)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e461f1a8832baea2ba23c24dc0fe