### PR TITLE
Strip Origin header from proxy requests

### DIFF
--- a/frontend/app/api/proxy/[...path]/route.ts
+++ b/frontend/app/api/proxy/[...path]/route.ts
@@ -24,6 +24,8 @@ const HOP_BY_HOP = [
   "upgrade",
   "host",
   "content-length",
+  // Strip origin so backend CORS rules don't see the browser origin
+  "origin",
 ];
 
 function cleanReqHeaders(h: Headers) {


### PR DESCRIPTION
## Summary
- Drop the `Origin` header when the Vercel proxy forwards requests so the Render backend no longer rejects them by CORS

## Testing
- ❌ `pytest backend` (1 failing test: summariser expected `messages` field)
- ⚠️ `npm test` (jest missing; `npm install` forbidden by registry)

------
https://chatgpt.com/codex/tasks/task_e_68a8efa968d0832bb9f606655e3fb843