### PR TITLE
fix: use browser-like user agent to prevent 403 on URL fetches

### DIFF
--- a/backend/server/services/fetcher.py
+++ b/backend/server/services/fetcher.py
@@ -24,9 +24,16 @@ from . import errors as err
 logger = logging.getLogger(__name__)
 
 # Request headers
+# Use a mainstream browser user-agent to avoid 403s from sites that block
+# unknown clients.
 HEADERS = {
-    "User-Agent": "LayScience/1.0 (+https://layscience.ai)",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/122.0.0.0 Safari/537.36"
+    ),
     "Accept": "text/html,application/pdf;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
 }
 
 DOI_RE = re.compile(r"^10\.\d{4,9}/[-._;()/:A-Z0-9]+$", re.IGNORECASE)

--- a/backend/tests/test_summarizer.py
+++ b/backend/tests/test_summarizer.py
@@ -18,11 +18,15 @@ def test_summarise_uses_messages(monkeypatch):
         def __init__(self):
             self.responses = FakeResponses()
 
+        def with_options(self, **kwargs):
+            # summariser expects client.with_options(...).responses
+            return self
+
     monkeypatch.setattr(summarizer, 'OpenAI', FakeClient)
 
     summarizer.summarise('text', {}, 'default', system_prompt='sys')
-    assert 'messages' in calls['kwargs']
-    msgs = calls['kwargs']['messages']
+    assert 'input' in calls['kwargs']
+    msgs = calls['kwargs']['input']
     assert msgs[0]['role'] == 'system'
     assert msgs[0]['content'] == 'sys'
 


### PR DESCRIPTION
## Summary
- use a mainstream browser `User-Agent` and language header in fetcher to avoid HTTP 403 on URL requests
- update summarizer test helper to support `with_options` and expect `input` payload

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9397933b4832bb3b258697037440f