### PR TITLE
Add footer disclaimer about AI testing status

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -22,6 +22,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${heading.variable} ${body.variable}`}>
       <body>
         {children}
+        <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
+          AI can make mistakes. LayScience is still in test.
+        </p>
         <ClientToaster />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Display a small footer note across the frontend reminding users that AI can make mistakes and LayScience remains in testing.

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68a93c03c8a8832bb35d81eedcf69b4b