### PR TITLE
style: redesign summarize button

### DIFF
--- a/frontend/app/summarize/page.tsx
+++ b/frontend/app/summarize/page.tsx
@@ -111,11 +111,10 @@ export default function Home() {
               </div>
               <button
                 type="button"
-                className="text-neutral-400 hover:text-white disabled:opacity-50 w-full sm:w-auto flex items-center justify-center"
+                className="text-neutral-400 hover:text-white disabled:opacity-50 w-full sm:w-auto flex items-center justify-center border border-neutral-700 bg-neutral-800 rounded-full px-4 py-2 sm:h-full"
                 onClick={onStart}
                 disabled={busy}
               >
-                <span className="mr-2 inline-block h-2 w-2 rounded-full border border-current"></span>
                 Summarize
               </button>
             </div>


### PR DESCRIPTION
## Summary
- restyle Summarize button with pill shape matching input height
- remove leading decorative circle icon

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a940e19900832b92e1dfc9daa3c1dc