### PR TITLE
Improve SEO with metadata and sitemap

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,11 +5,32 @@ import { Bebas_Neue, Inter } from "next/font/google";
 
 const heading = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-heading" });
 const body = Inter({ subsets: ["latin"], variable: "--font-body" });
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://layscience.onrender.com";
 
 export const metadata: Metadata = {
-  title: "Lay Science",
+  metadataBase: new URL(baseUrl),
+  title: {
+    default: "Lay Science",
+    template: "%s | Lay Science",
+  },
   description: "AI that turns research into clear, engaging summaries.",
   icons: { icon: "/icon.png" },
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: "Lay Science",
+    description: "AI that turns research into clear, engaging summaries.",
+    url: baseUrl,
+    siteName: "Lay Science",
+    images: [{ url: "/icon.png", width: 96, height: 96 }],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Lay Science",
+    description: "AI that turns research into clear, engaging summaries.",
+    images: ["/icon.png"],
+  },
 };
 
 export const viewport: Viewport = {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,9 +4,16 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import toast from "react-hot-toast";
+import type { Metadata } from "next";
 import { registerAccount, verifyCode } from "@/lib/api";
 
 console.info("API base", process.env.NEXT_PUBLIC_API_BASE);
+
+export const metadata: Metadata = {
+  title: "Welcome",
+  description:
+    "Create an account or test Lay Science—the AI that turns research into clear, engaging summaries.",
+};
 
 export default function Welcome() {
   const [step, setStep] = useState<"choice" | "register" | "verify">("choice");

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://layscience.onrender.com";
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://layscience.onrender.com";
+  const lastModified = new Date();
+  return [
+    {
+      url: baseUrl,
+      lastModified,
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/summarize`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/frontend/app/summarize/page.tsx
+++ b/frontend/app/summarize/page.tsx
@@ -2,9 +2,16 @@
 
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
+import type { Metadata } from "next";
 import { startJob, getJob, getSummary } from "@/lib/api";
 
 type HistoryItem = { type: "link" | "pdf"; value: string; name?: string };
+
+export const metadata: Metadata = {
+  title: "Summarize Research",
+  description:
+    "Upload a paper or enter a DOI/URL to get a concise AI-generated summary from Lay Science.",
+};
 
 export default function Home() {
   const [ref, setRef] = useState("");


### PR DESCRIPTION
## Summary
- expand global metadata with canonical URL, Open Graph, and Twitter tags
- add page-level metadata for welcome and summarize pages
- generate robots.txt and sitemap.xml for better search engine indexing

## Testing
- `npm install` *(failed: 403 Forbidden for packages)*
- `npm test` *(failed: jest: not found)*
- `npm run lint` *(failed: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94a097c2c832baee167d60b223358