### PR TITLE
feat: add notice about commercial licensing

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -71,6 +71,9 @@ export default function Welcome() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
           />
+          <p className="text-sm text-neutral-400">
+            Lay Science is free for personal use. Contact us for commercial licensing.
+          </p>
           <button
             className="w-full rounded bg-white/10 hover:bg-white/20 py-2"
             onClick={onRegister}


### PR DESCRIPTION
## Summary
- note that account creation is free for personal use and requires a commercial license for business use

## Testing
- `pytest`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94aa48390832bb4a4d352289bec8d