### PR TITLE
Add about page

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center bg-neutral-950 text-neutral-100 px-6 py-12 text-center">
+      <h1 className="font-heading text-3xl mb-6">About LayScience</h1>
+      <p className="max-w-prose mb-4">
+        LayScience is an AI tool that turns research papers (PDF, DOI, or URL) into clear, trustworthy plain-language summaries—either ultra-short “micro-stories” or more detailed write-ups. It’s built first for Kabul University female students—and for anyone who finds papers long, technical, or hard to follow—to help spark curiosity and make open science genuinely accessible.
+      </p>
+      <p className="max-w-prose">
+        You can run up to five summaries without an account; for more, please create a free account. If you’re able, consider chipping in to help cover hosting and API costs so the service stays available to people who can’t afford much. Created by Rashid Mushkani, 2025. © 2025 Rashid Mushkani. All rights reserved.
+      </p>
+    </main>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import ClientToaster from "@/components/ClientToaster";
+import Link from "next/link";
 import { Bebas_Neue, Inter } from "next/font/google";
 
 const heading = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-heading" });
@@ -40,14 +41,20 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${heading.variable} ${body.variable}`}>
-      <body>
-        {children}
-        <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
-          AI can make mistakes. LayScience is still in test.
-        </p>
-        <ClientToaster />
-      </body>
-    </html>
+      <html lang="en" className={`${heading.variable} ${body.variable}`}>
+        <body>
+          <Link
+            href="/about"
+            className="fixed top-2 right-2 text-xs text-neutral-400 hover:text-neutral-200"
+          >
+            about
+          </Link>
+          {children}
+          <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
+            AI can make mistakes. LayScience is still in test.
+          </p>
+          <ClientToaster />
+        </body>
+      </html>
   );
 }


### PR DESCRIPTION
## Summary
- add new About page with mission, usage limits, and attribution details
- add persistent top-right link to About page across the site

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c2e7810c832bb40f3731e5a21bdd