### PR TITLE
Add comprehensive README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Rashid Mushkani
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,59 @@
 # LayScience
 
-The application is deployed at [layscience.onrender.com](https://layscience.onrender.com/).
+LayScience is an AI-powered tool that turns research papers (PDF, DOI, or URL) into clear and trustworthy plain-language summaries. It can generate ultra-short "micro-stories" or more detailed write-ups and highlights the exact lines or figures behind each claim with transparent source bubbles. Built first for Kabul University female students—and for anyone who finds papers long, technical, or hard to follow—it aims to spark curiosity and make open science accessible.
 
+The web app is live at [layscience.onrender.com](https://layscience.onrender.com/). You can run up to five summaries without an account; create a free account for unlimited use. If you're able, donations help cover hosting and API costs so the service stays available to those who can't afford much.
+
+## Repository Structure
+
+- `backend/` – FastAPI service that extracts paper text and calls OpenAI's GPT-5 Responses API.
+- `frontend/` – Next.js 14 web app that provides the user interface.
+- `data/` – Stores uploaded PDFs and a SQLite job database.
+
+## Local Development
+
+### Backend
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+export OPENAI_API_KEY=sk-...
+uvicorn backend.server.main:app --reload
+```
+
+Additional environment variables such as `OPENAI_MODEL`, `ALLOWED_ORIGINS`, and SMTP settings are documented in [backend/README.md](backend/README.md).
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+export NEXT_PUBLIC_API_BASE=http://127.0.0.1:8000
+npm run dev
+```
+
+Open <http://localhost:3000> and enter a DOI/URL or upload a PDF to create a summary.
+
+## Testing
+
+Run the test suites before submitting changes:
+
+```bash
+pytest backend
+cd frontend && npm test
+```
+
+## Deployment and Hosting
+
+The production instance runs on [Render](https://render.com), which hosts the FastAPI backend and serves the Next.js frontend. Any platform that can build and run Docker or Node/Python apps (Render, Vercel, Netlify, etc.) can host LayScience. Ensure the environment variables listed above are set in your deployment environment.
+
+## Contributing
+
+Pull requests and issues are welcome. Please make sure the tests pass and follow the project coding style when contributing.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+Created by Rashid Mushkani, 2025.


### PR DESCRIPTION
## Summary
- expand top-level README with project description, setup, testing, and deployment details
- add MIT license

## Testing
- `JOBS_DB_PATH=/tmp/jobs.sqlite3 pytest backend`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c554239c832b884e21dc5fda5fd8