### PR TITLE
Add mode and language selectors to customize lay summaries

### DIFF
--- a/frontend/app/summarize/page.tsx
+++ b/frontend/app/summarize/page.tsx
@@ -25,6 +25,10 @@ export default function Home() {
   const [hasAccount, setHasAccount] = useState(false);
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [dragOver, setDragOver] = useState(false);
+  const [mode, setMode] = useState<"default" | "detailed" | "funny">("default");
+  const [language, setLanguage] = useState<"en" | "fa" | "fr" | "es" | "de">(
+    "en"
+  );
 
   function reset() {
     setJobId(null);
@@ -56,7 +60,13 @@ export default function Home() {
       } else if (ref) {
         addToHistory({ type: "link", value: ref });
       }
-      const res = await startJob({ ref: ref || undefined, file, length: "default" });
+      const res = await startJob({
+        ref: ref || undefined,
+        file,
+        length: mode === "detailed" ? "extended" : "default",
+        mode,
+        language,
+      });
       setJobId(res.id);
       setStatus("queued");
       toast.success("Job started");
@@ -166,6 +176,28 @@ export default function Home() {
               >
                 Summarize
               </button>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <select
+                className="flex-1 bg-neutral-900/60 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200"
+                value={mode}
+                onChange={(e) => setMode(e.target.value as any)}
+              >
+                <option value="default">Default</option>
+                <option value="detailed">Detailed</option>
+                <option value="funny">Funny</option>
+              </select>
+              <select
+                className="flex-1 bg-neutral-900/60 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200"
+                value={language}
+                onChange={(e) => setLanguage(e.target.value as any)}
+              >
+                <option value="en">English</option>
+                <option value="fa">Persian</option>
+                <option value="fr">French</option>
+                <option value="es">Spanish</option>
+                <option value="de">German</option>
+              </select>
             </div>
             {file && <p className="mt-2 text-xs text-neutral-400">Selected: {file.name}</p>}
             {history.length > 0 && (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -44,14 +44,28 @@ async function asJson(res: Response) {
 }
 
 type LengthOpt = "default" | "extended";
+type ModeOpt = "default" | "detailed" | "funny";
+type LanguageOpt = "en" | "fa" | "fr" | "es" | "de";
 
-export async function startJob({ ref, file, length = "default" }: {
-  ref?: string; file?: File | null; length?: LengthOpt;
+export async function startJob({
+  ref,
+  file,
+  length = "default",
+  mode = "default",
+  language = "en",
+}: {
+  ref?: string;
+  file?: File | null;
+  length?: LengthOpt;
+  mode?: ModeOpt;
+  language?: LanguageOpt;
 }) {
   if (file) {
     const fd = new FormData();
     if (ref) fd.set("ref", ref);
     fd.set("length", length);
+    fd.set("mode", mode);
+    fd.set("language", language);
     fd.set("pdf", file, file.name);
     const res = await fetch(api("/api/v1/summaries"), {
       method: "POST",
@@ -63,7 +77,7 @@ export async function startJob({ ref, file, length = "default" }: {
     const res = await fetch(api("/api/v1/summaries"), {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ref, length }),
+      body: JSON.stringify({ ref, length, mode, language }),
       cache: "no-store",
     });
     return asJson(res);


### PR DESCRIPTION
## Summary
- Add mode (Default, Detailed, Funny) and language options to the summarise UI
- Send chosen mode and language to the backend and adjust OpenAI system prompt accordingly
- Validate and store new options on the server with tests for custom mode/language

## Testing
- `pytest`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c5024e0c832bb1c8d21310937730