### PR TITLE
Toggle about link and prompt sign-up after limit

### DIFF
--- a/frontend/__tests__/limit.test.tsx
+++ b/frontend/__tests__/limit.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Summarize from '../components/Summarize';
+
+describe('Summarize limit', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows create account button when limit reached', () => {
+    localStorage.setItem('testCount', '5');
+    render(<Summarize />);
+    expect(screen.getByText(/test limit reached/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /create account/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import ClientToaster from "@/components/ClientToaster";
-import Link from "next/link";
+import AboutHomeLink from "@/components/AboutHomeLink";
 import { Bebas_Neue, Inter } from "next/font/google";
 
 const heading = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-heading" });
@@ -43,12 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
       <html lang="en" className={`${heading.variable} ${body.variable}`}>
         <body>
-          <Link
-            href="/about"
-            className="fixed top-2 right-2 text-xs text-neutral-400 hover:text-neutral-200"
-          >
-            about
-          </Link>
+          <AboutHomeLink />
           {children}
           <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
             AI can make mistakes. LayScience is still in test.

--- a/frontend/components/AboutHomeLink.tsx
+++ b/frontend/components/AboutHomeLink.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function AboutHomeLink() {
+  const pathname = usePathname();
+  const isAbout = pathname?.startsWith("/about");
+
+  return (
+    <Link
+      href={isAbout ? "/" : "/about"}
+      className="fixed top-2 right-2 text-xs text-neutral-400 hover:text-neutral-200"
+    >
+      {isAbout ? "home" : "about"}
+    </Link>
+  );
+}

--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import toast from "react-hot-toast";
 import { startJob, getJob, getSummary } from "@/lib/api";
 
@@ -121,7 +122,19 @@ export default function Summarize() {
           <h1 className="font-heading text-4xl sm:text-5xl mb-2">Lay Science</h1>
           <p className="text-neutral-400 mb-8 text-sm sm:text-base">AI that turns research into clear, engaging summaries.</p>
           {!hasAccount && (
-            <p className="text-neutral-400 mb-4 text-sm">Tests remaining: {Math.max(0,5 - testCount)}</p>
+            testCount < 5 ? (
+              <p className="text-neutral-400 mb-4 text-sm">Tests remaining: {5 - testCount}</p>
+            ) : (
+              <div className="text-neutral-400 mb-4 text-sm flex flex-col items-center gap-2">
+                <p>Test limit reached.</p>
+                <Link
+                  href="/"
+                  className="rounded bg-white/10 px-3 py-1 text-neutral-100 hover:bg-white/20"
+                >
+                  Create account
+                </Link>
+              </div>
+            )
           )}
           <div className="w-full max-w-xl">
             <div


### PR DESCRIPTION
## Summary
- swap about page link to home when viewing About
- show a create account button when a guest hits the five-use limit
- add test for limit warning and new about/home link component

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19ac8088832b98eb71c49d29e1de