### PR TITLE
Add referer header when fetching papers

### DIFF
--- a/backend/server/services/fetcher.py
+++ b/backend/server/services/fetcher.py
@@ -34,8 +34,10 @@ HEADERS = {
     ),
     "Accept": "text/html,application/pdf;q=0.9,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.9",
-    # Some hosts return 403 unless a typical browser encoding header is present
+    # Some hosts return 403 unless typical browser headers are present
     "Accept-Encoding": "gzip, deflate, br",
+    # A generic referer helps with servers that block direct, non-browser fetches
+    "Referer": "https://www.google.com",
 }
 
 DOI_RE = re.compile(r"^10\.\d{4,9}/[-._;()/:A-Z0-9]+$", re.IGNORECASE)


### PR DESCRIPTION
## Summary
- Send a generic `Referer` header with all HTTP requests to better mimic a real browser and bypass 403 blocks from some publishers.

## Testing
- `pytest backend`
- `cd frontend && npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a584c58832b93762ec56c655616