### PR TITLE
feat: harden verification flow with resend endpoint

### DIFF
--- a/backend/tests/test_registration.py
+++ b/backend/tests/test_registration.py
@@ -50,6 +50,7 @@ def test_register_sends_email(monkeypatch):
         "/api/v1/register", json={"username": "alice", "email": "alice@example.com"}
     )
     assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
     assert captured["host"] == "smtp.example.com"
     assert captured["port"] == 587
     assert captured["to"] == "alice@example.com"

--- a/backend/tests/test_resend.py
+++ b/backend/tests/test_resend.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from backend.server import main
+
+client = TestClient(main.app)
+
+
+def test_resend_reuses_code(monkeypatch):
+    email = "bob@example.com"
+    monkeypatch.setattr(main, "_generate_code", lambda: "654321")
+    client.post("/api/v1/register", json={"username": "bob", "email": email})
+    # change generator to ensure resend doesn't use new code
+    monkeypatch.setattr(main, "_generate_code", lambda: "999999")
+    resp = client.post("/api/v1/resend", json={"email": email})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "resent"
+    assert main.pending_codes[email]["code"] == "654321"
+
+
+def test_code_expiry(monkeypatch):
+    email = "carol@example.com"
+    monkeypatch.setattr(main, "_generate_code", lambda: "111111")
+    client.post("/api/v1/register", json={"username": "carol", "email": email})
+    # force expiry
+    main.pending_codes[email]["expires_at"] = datetime.utcnow() - timedelta(seconds=1)
+    bad = client.post("/api/v1/verify", json={"email": email, "code": "111111"})
+    assert bad.status_code == 400


### PR DESCRIPTION
## Summary
- hash verification codes and add expiry
- add `/api/v1/resend` endpoint with code reuse
- adjust tests for new flow and cover resend/expiry

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2d8e8204832ba6da7a4cbd922b2e