### PR TITLE
feat: add user fab and account panel

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import ClientToaster from "@/components/ClientToaster";
 import AboutHomeLink from "@/components/AboutHomeLink";
+import UserFab from "@/components/UserFab";
 import { Bebas_Neue, Inter } from "next/font/google";
 
 const heading = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-heading" });
@@ -45,6 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <body>
           <AboutHomeLink />
           {children}
+          <UserFab />
           <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
             AI can make mistakes. LayScience is still in test.
           </p>

--- a/frontend/components/Feedback/FeedbackTab.tsx
+++ b/frontend/components/Feedback/FeedbackTab.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function FeedbackTab() {
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-neutral-300">Feedback forum coming soon.</p>
+    </div>
+  );
+}
+

--- a/frontend/components/UserFab.tsx
+++ b/frontend/components/UserFab.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import UserPanel from "./UserPanel";
+
+export default function UserFab() {
+  const [open, setOpen] = useState(false);
+  const [user, setUser] = useState<{ username?: string; email?: string } | null>(null);
+
+  useEffect(() => {
+    const username = localStorage.getItem("username") || undefined;
+    const email = localStorage.getItem("email") || undefined;
+    const hasAccount = localStorage.getItem("hasAccount") === "true";
+    if (hasAccount && (username || email)) {
+      setUser({ username, email });
+    }
+  }, []);
+
+  if (!user) return null;
+
+  function getInitials() {
+    const name = user.username || "";
+    if (name.trim().length === 0 && user.email) {
+      return user.email.charAt(0).toUpperCase();
+    }
+    const parts = name.trim().split(/\s+/);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+    return parts[0][0].toUpperCase();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed left-4 bottom-4 z-50 h-10 w-10 rounded-full flex items-center justify-center bg-neutral-800 text-white shadow-lg"
+      >
+        {getInitials()}
+      </button>
+      {open && <UserPanel onClose={() => setOpen(false)} user={user} />}
+    </>
+  );
+}
+

--- a/frontend/components/UserPanel.tsx
+++ b/frontend/components/UserPanel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import FeedbackTab from "./Feedback/FeedbackTab";
+
+interface Props {
+  onClose: () => void;
+  user: { username?: string; email?: string };
+}
+
+function SummariesTab() {
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-neutral-300">Your recent summaries will appear here.</p>
+    </div>
+  );
+}
+
+function AccountTab({ user, onDelete }: { user: { username?: string; email?: string }; onDelete: () => void }) {
+  return (
+    <div className="space-y-4 text-sm">
+      <p><strong>User:</strong> {user.username || user.email}</p>
+      <p><strong>Email:</strong> {user.email}</p>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="rounded bg-red-600/20 px-3 py-2 text-red-200 hover:bg-red-600/30"
+      >
+        Delete my account
+      </button>
+    </div>
+  );
+}
+
+export default function UserPanel({ onClose, user }: Props) {
+  const tabs = ["Summaries", "Feedback", "Account"] as const;
+  type Tab = (typeof tabs)[number];
+  const [tab, setTab] = useState<Tab>("Summaries");
+
+  return (
+    <div className="fixed inset-0 z-50 flex" onClick={onClose}>
+      <div
+        className="ml-4 mb-4 self-end w-full max-w-sm rounded-lg bg-neutral-900 text-neutral-100 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex border-b border-neutral-700">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`flex-1 py-2 text-sm ${tab === t ? "bg-neutral-800" : ""}`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <div className="p-4 max-h-80 overflow-y-auto">
+          {tab === "Summaries" && <SummariesTab />}
+          {tab === "Feedback" && <FeedbackTab />}
+          {tab === "Account" && <AccountTab user={user} onDelete={() => {}} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/components/Welcome.tsx
+++ b/frontend/components/Welcome.tsx
@@ -26,6 +26,8 @@ export default function Welcome() {
     try {
       await verifyCode({ email, code });
       localStorage.setItem("hasAccount", "true");
+      localStorage.setItem("username", username);
+      localStorage.setItem("email", email);
       toast.success("Account verified");
       setStep("choice");
     } catch (e: any) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -113,3 +113,73 @@ export async function verifyCode({ email, code }: { email: string; code: string 
   });
   return asJson(res);
 }
+
+export async function resendCode(email: string) {
+  const res = await fetch(api("/api/v1/resend"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email }),
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function deleteAccount() {
+  const res = await fetch(api("/api/v1/account"), {
+    method: "DELETE",
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function listMySummaries(page = 1) {
+  const res = await fetch(api(`/api/v1/summaries?me=true&page=${page}`), {
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function listFeedbackTopics(page = 1) {
+  const res = await fetch(api(`/api/v1/feedback/topics?page=${page}`), {
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function createFeedbackTopic({ title, body }: { title: string; body: string }) {
+  const res = await fetch(api("/api/v1/feedback/topics"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ title, body }),
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function listFeedbackReplies(topicId: number) {
+  const res = await fetch(api(`/api/v1/feedback/topics/${topicId}/replies`), {
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function createFeedbackReply(topicId: number, body: string) {
+  const res = await fetch(api(`/api/v1/feedback/topics/${topicId}/replies`), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ body }),
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+
+export async function submitFeedbackSurvey(q1: string, q2: number, q3: string) {
+  const res = await fetch(api("/api/v1/feedback/survey"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ q1, q2, q3 }),
+    cache: "no-store",
+  });
+  return asJson(res);
+}
+


### PR DESCRIPTION
## Summary
- add floating user avatar button and account panel
- store username/email after verification
- extend API client for account and feedback endpoints

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3990920c832bb17db18a87feb594