### PR TITLE
Style language and mode selectors as pill buttons

### DIFF
--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -186,9 +186,9 @@ export default function Summarize() {
                 Summarize
               </button>
             </div>
-            <div className="mt-4 flex gap-2">
+            <div className="mt-4 flex flex-wrap justify-center gap-2">
               <select
-                className="flex-1 bg-neutral-900/60 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200"
+                className="bg-neutral-900/60 border border-neutral-700 rounded-full px-3 py-2 text-sm text-neutral-200 w-auto"
                 value={mode}
                 onChange={(e) => setMode(e.target.value as any)}
               >
@@ -197,7 +197,7 @@ export default function Summarize() {
                 <option value="funny">Funny</option>
               </select>
               <select
-                className="flex-1 bg-neutral-900/60 border border-neutral-700 rounded-md px-3 py-2 text-sm text-neutral-200"
+                className="bg-neutral-900/60 border border-neutral-700 rounded-full px-3 py-2 text-sm text-neutral-200 w-auto"
                 value={language}
                 onChange={(e) => setLanguage(e.target.value as any)}
               >


### PR DESCRIPTION
## Summary
- Restyle mode and language selectors as rounded, content-sized pills placed below the Summarize action.

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3dee2808832b92e91f23d9ec29a0