### PR TITLE
Redirect verified users to summarize page

### DIFF
--- a/frontend/components/Welcome.tsx
+++ b/frontend/components/Welcome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import toast from "react-hot-toast";
@@ -11,6 +12,7 @@ export default function Welcome() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
+  const router = useRouter();
 
   async function onRegister() {
     try {
@@ -29,7 +31,7 @@ export default function Welcome() {
       localStorage.setItem("username", username);
       localStorage.setItem("email", email);
       toast.success("Account verified");
-      setStep("choice");
+      router.push("/summarize");
     } catch (e: any) {
       toast.error(e.message || "Verification failed");
     }


### PR DESCRIPTION
## Summary
- Redirect new verified users to the summarize page and store their details so the user badge appears

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68aa43d3bd08832ba8a78ce2e0f30bd7