### PR TITLE
fix: handle nullable user in getInitials

### DIFF
--- a/frontend/components/UserFab.tsx
+++ b/frontend/components/UserFab.tsx
@@ -18,7 +18,7 @@ export default function UserFab() {
 
   if (!user) return null;
 
-  function getInitials() {
+  function getInitials(user: { username?: string; email?: string }) {
     const name = user.username || "";
     if (name.trim().length === 0 && user.email) {
       return user.email.charAt(0).toUpperCase();
@@ -37,7 +37,7 @@ export default function UserFab() {
         onClick={() => setOpen(true)}
         className="fixed left-4 bottom-4 z-50 h-10 w-10 rounded-full flex items-center justify-center bg-neutral-800 text-white shadow-lg"
       >
-        {getInitials()}
+        {getInitials(user)}
       </button>
       {open && <UserPanel onClose={() => setOpen(false)} user={user} />}
     </>


### PR DESCRIPTION
## Summary
- handle nullable user in UserFab getInitials

## Testing
- `npm ci` (fails: 403 Forbidden)
- `npm test` (fails: sh: 1: jest: not found)
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa44c5d0c0832b9a9c390f1b2ba29b