### PR TITLE
Fix spacing after email address on About page

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -17,9 +17,9 @@ export default function AboutPage() {
       <p className="max-w-prose mt-4">
         Contact me at
         <a href="mailto:rashidmushkani@gmail.com" className="underline ml-1">
-          rashidmushkani@gmail.com 
-        </a>
-         for questions or feedback.
+          rashidmushkani@gmail.com
+        </a>{" "}
+        for questions or feedback.
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- ensure about page email and following text have a space between them

## Testing
- `pytest`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa48f6dbac832ba94ed03933bd4ae5