### PR TITLE
feat: add arxiv search and integration

### DIFF
--- a/backend/server/services/arxiv.py
+++ b/backend/server/services/arxiv.py
@@ -1,0 +1,119 @@
+"""Simple arXiv API client utilities.
+
+Provides functions to search arXiv by title or keyword and to construct
+PDF URLs for a given arXiv identifier.
+
+The main helper :func:`search` performs a query against the arXiv API
+and returns a normalised list of result dictionaries containing
+``title``, ``authors``, ``id``, ``links``, ``published``, ``updated`` and
+``categories`` fields.
+"""
+
+from __future__ import annotations
+
+import httpx
+from typing import List, Dict, Any
+from xml.etree import ElementTree as ET
+from urllib.parse import quote_plus
+
+API_URL = "https://export.arxiv.org/api/query"
+
+
+def _parse_atom(xml_text: str) -> List[Dict[str, Any]]:
+    """Parse an Atom XML string returned by arXiv.
+
+    Parameters
+    ----------
+    xml_text:
+        Raw Atom feed as returned by the arXiv API.
+
+    Returns
+    -------
+    list of dict
+        Normalised result dictionaries.
+    """
+    root = ET.fromstring(xml_text)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    results: List[Dict[str, Any]] = []
+    for entry in root.findall("atom:entry", ns):
+        # Extract basic fields
+        raw_id = entry.findtext("atom:id", default="", namespaces=ns)
+        arxiv_id = raw_id.rsplit("/", 1)[-1]
+        title = entry.findtext("atom:title", default="", namespaces=ns)
+        title = " ".join(title.split())  # normalise whitespace
+        published = entry.findtext("atom:published", default="", namespaces=ns)
+        updated = entry.findtext("atom:updated", default="", namespaces=ns)
+
+        # Authors
+        authors = [
+            a.findtext("atom:name", default="", namespaces=ns)
+            for a in entry.findall("atom:author", ns)
+        ]
+        authors = [a for a in authors if a]
+
+        # Links
+        links: Dict[str, str] = {}
+        for link in entry.findall("atom:link", ns):
+            href = link.attrib.get("href")
+            if not href:
+                continue
+            rel = link.attrib.get("rel")
+            typ = link.attrib.get("type")
+            if typ == "application/pdf" or href.lower().endswith(".pdf"):
+                links["pdf"] = href
+            elif rel == "alternate":
+                links["html"] = href
+
+        # Categories
+        categories = [
+            c.attrib.get("term")
+            for c in entry.findall("atom:category", ns)
+            if c.attrib.get("term")
+        ]
+
+        results.append(
+            {
+                "id": arxiv_id,
+                "title": title,
+                "authors": authors,
+                "links": links,
+                "published": published,
+                "updated": updated,
+                "categories": categories,
+            }
+        )
+    return results
+
+
+def search(query: str, max_results: int = 20) -> List[Dict[str, Any]]:
+    """Search arXiv for ``query`` and return normalised results.
+
+    Parameters
+    ----------
+    query:
+        Search query to run against arXiv's API.  It will be URL encoded
+        and passed as ``search_query=all:<query>``.
+    max_results:
+        Maximum number of results to retrieve (default 20).
+    """
+    params = {
+        "search_query": f"all:{quote_plus(query)}",
+        "start": 0,
+        "max_results": max_results,
+    }
+    # Use httpx for consistency with the rest of the project
+    r = httpx.get(API_URL, params=params, timeout=20.0)
+    r.raise_for_status()
+    return _parse_atom(r.text)
+
+
+def pdf_url(arxiv_id: str) -> str:
+    """Return the canonical PDF URL for ``arxiv_id``.
+
+    Examples
+    --------
+    >>> pdf_url("1234.5678v1")
+    'https://arxiv.org/pdf/1234.5678v1.pdf'
+    """
+    arxiv_id = arxiv_id.split("/")[-1]
+    return f"https://arxiv.org/pdf/{arxiv_id}.pdf"

--- a/backend/tests/test_arxiv.py
+++ b/backend/tests/test_arxiv.py
@@ -1,0 +1,59 @@
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.server.main import app
+from backend.server.services import arxiv
+
+SAMPLE_FEED = """<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns='http://www.w3.org/2005/Atom'>
+  <entry>
+    <id>http://arxiv.org/abs/1234.5678v1</id>
+    <title>Sample Paper</title>
+    <summary>Example</summary>
+    <published>2020-01-01T00:00:00Z</published>
+    <updated>2020-01-02T00:00:00Z</updated>
+    <author><name>John Doe</name></author>
+    <author><name>Jane Smith</name></author>
+    <link rel='alternate' type='text/html' href='http://arxiv.org/abs/1234.5678v1'/>
+    <link rel='related' type='application/pdf' href='http://arxiv.org/pdf/1234.5678v1'/>
+    <category term='cs.AI' scheme='http://arxiv.org/schemas/atom'/>
+  </entry>
+</feed>"""
+
+
+def fake_get(url, params=None, timeout=None):
+    class R:
+        status_code = 200
+        text = SAMPLE_FEED
+
+        def raise_for_status(self):
+            pass
+
+    return R()
+
+
+def test_search_parses(monkeypatch):
+    monkeypatch.setattr(httpx, "get", fake_get)
+    res = arxiv.search("quantum")
+    assert len(res) == 1
+    item = res[0]
+    assert item["id"] == "1234.5678v1"
+    assert item["title"] == "Sample Paper"
+    assert item["authors"] == ["John Doe", "Jane Smith"]
+    assert item["links"]["pdf"].endswith("1234.5678v1")
+    assert item["categories"] == ["cs.AI"]
+
+
+def test_pdf_url():
+    assert arxiv.pdf_url("1234.5678v1") == "https://arxiv.org/pdf/1234.5678v1.pdf"
+
+
+def test_search_endpoint(monkeypatch):
+    monkeypatch.setattr(httpx, "get", fake_get)
+    client = TestClient(app)
+    r = client.get("/api/v1/arxiv/search", params={"q": "quantum"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["count"] == 1
+    assert data["results"][0]["id"] == "1234.5678v1"

--- a/frontend/components/ArxivSearch.tsx
+++ b/frontend/components/ArxivSearch.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { searchArxiv } from "@/lib/api";
+
+interface Props {
+  onSelect: (pdfUrl: string) => void;
+}
+
+export default function ArxivSearch({ onSelect }: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<any[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  async function doSearch() {
+    if (!query.trim()) return;
+    try {
+      setBusy(true);
+      const res = await searchArxiv(query.trim());
+      setResults(res.results || []);
+    } catch (e: any) {
+      toast.error(e.message || "Search failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-xl mx-auto mt-8">
+      <h2 className="text-center mb-4 text-neutral-200">Search arXiv</h2>
+      <div className="flex gap-2 mb-4">
+        <input
+          className="flex-1 bg-neutral-900/60 border border-neutral-700 rounded-full px-4 py-2 text-neutral-200"
+          placeholder="Keywords or title"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") doSearch();
+          }}
+        />
+        <button
+          type="button"
+          className="border border-neutral-700 bg-neutral-800 rounded-full px-4 py-2 text-neutral-200 disabled:opacity-50"
+          onClick={doSearch}
+          disabled={busy}
+        >
+          Search
+        </button>
+      </div>
+      {results.length > 0 && (
+        <ul className="space-y-4">
+          {results.map((r) => (
+            <li
+              key={r.id}
+              className="border border-neutral-700 rounded-lg p-4 bg-neutral-900/60"
+            >
+              <h3 className="text-neutral-100 font-semibold">{r.title}</h3>
+              {r.authors && (
+                <p className="text-neutral-400 text-sm">
+                  {(r.authors as string[]).join(", ")}
+                </p>
+              )}
+              {r.categories && (
+                <p className="text-neutral-500 text-xs mb-2">
+                  {(r.categories as string[]).join(", ")}
+                </p>
+              )}
+              <div className="flex gap-2">
+                <a
+                  href={r.links?.html || `https://arxiv.org/abs/${r.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 text-sm underline"
+                >
+                  View
+                </a>
+                {r.links?.pdf && (
+                  <button
+                    type="button"
+                    className="text-neutral-200 text-sm border border-neutral-700 rounded px-2 py-1 hover:bg-neutral-800"
+                    onClick={() => onSelect(r.links.pdf)}
+                  >
+                    Summarize
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -94,6 +94,14 @@ export async function getSummary(id: string) {
   return asJson(res);
 }
 
+export async function searchArxiv(query: string, maxResults = 20) {
+  const res = await fetch(
+    api(`/api/v1/arxiv/search?q=${encodeURIComponent(query)}&max_results=${maxResults}`),
+    { cache: "no-store" }
+  );
+  return asJson(res);
+}
+
 export async function registerAccount({ username, email }: { username: string; email: string }) {
   const res = await fetch(api("/api/v1/register"), {
     method: "POST",


### PR DESCRIPTION
## Summary
- add arXiv service for keyword search and PDF URL construction
- expose `/api/v1/arxiv/search` and `/api/v1/arxiv/pdf/{id}` endpoints
- integrate frontend search component to summarize selected arXiv papers

## Testing
- `pytest backend`
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa531aaa5c832baeb35572db6b7d3f