### PR TITLE
Redirect existing users to summary page on home link

### DIFF
--- a/frontend/components/Welcome.tsx
+++ b/frontend/components/Welcome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
@@ -13,6 +13,12 @@ export default function Welcome() {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && localStorage.getItem("hasAccount") === "true") {
+      router.replace("/summarize");
+    }
+  }, [router]);
 
   async function onRegister() {
     try {


### PR DESCRIPTION
## Summary
- Redirect visitors who already have an account to `/summarize` when they go to the home page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa54cded14832b8bb1be9be3b705cb