### PR TITLE
Persist account data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pnpm-debug.log*
 
 # --- App-local data ---
 uploads/
+data/accounts.json
+data/pending_codes.json


### PR DESCRIPTION
## Summary
- persist account registrations and verification codes to JSON files under DATA_DIR
- save updates from register, resend and verify endpoints
- ignore generated account data files in git

## Testing
- `PYTHONDONTWRITEBYTECODE=1 JOBS_DB_PATH=/tmp/jobs.sqlite3 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa545275f0832b9abb51d8bf97cb0f