### PR TITLE
Align recent references sidebar width with user panel

### DIFF
--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -143,7 +143,7 @@ export default function Summarize() {
   return (
     <main className="min-h-dvh flex bg-neutral-950 text-neutral-100">
       {history.length > 0 && (
-        <aside className="w-64 max-h-dvh overflow-y-auto border-r border-neutral-800 p-4 text-sm text-neutral-400">
+        <aside className="w-full max-w-sm max-h-dvh overflow-y-auto border-r border-neutral-800 p-4 text-sm text-neutral-400">
           <p className="mb-2">Recent references:</p>
           <ul className="space-y-1">
             {history.map((h, i) => (


### PR DESCRIPTION
## Summary
- match width of left sidebar's "Recent references" with user panel popup

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: next not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa5995d7c0832bae92e8b417bc4ee8