### PR TITLE
Fix unescaped apostrophes in feedback prompt

### DIFF
--- a/frontend/components/Feedback/FeedbackTab.tsx
+++ b/frontend/components/Feedback/FeedbackTab.tsx
@@ -59,7 +59,7 @@ export default function FeedbackTab() {
       </label>
 
       <label className="block">
-        <span className="mb-1 block">What's one improvement you'd like to see?</span>
+        <span className="mb-1 block">What&apos;s one improvement you&apos;d like to see?</span>
         <textarea
           value={improvement}
           onChange={(e) => setImprovement(e.target.value)}


### PR DESCRIPTION
## Summary
- escape apostrophes in feedback question to satisfy React's no-unescaped-entities rule

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b6cb42c832bbf250d098357bff0