### PR TITLE
Move test notice to sidebar

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,10 +47,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <body>
           <AboutHomeLink />
           {children}
-          <UserFab />
-          <p className="fixed bottom-0 left-0 w-full pb-2 text-center text-xs text-neutral-400">
-            AI can make mistakes. LayScience is still in test.
-          </p>
+          <div className="fixed bottom-0 left-0 flex flex-col items-center p-4 gap-2">
+            <UserFab />
+            <p className="text-center text-xs text-neutral-400">
+              AI can make mistakes. LayScience is still in test.
+            </p>
+          </div>
           <ClientToaster />
         </body>
       </html>

--- a/frontend/components/UserFab.tsx
+++ b/frontend/components/UserFab.tsx
@@ -35,7 +35,7 @@ export default function UserFab() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="fixed left-4 bottom-4 z-50 h-10 w-10 rounded-full flex items-center justify-center bg-neutral-800 text-white shadow-lg"
+        className="z-50 h-10 w-10 rounded-full flex items-center justify-center bg-neutral-800 text-white shadow-lg"
       >
         {getInitials(user)}
       </button>


### PR DESCRIPTION
## Summary
- Position user menu and test disclaimer in a fixed sidebar at the bottom-left
- Update user button styling to allow placement within sidebar container

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa64737370832bae1f25ad1e73aca6