### PR TITLE
fix: support multi-word arXiv queries

### DIFF
--- a/backend/server/services/arxiv.py
+++ b/backend/server/services/arxiv.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import httpx
 from typing import List, Dict, Any
 from xml.etree import ElementTree as ET
-from urllib.parse import quote_plus
 
 API_URL = "https://export.arxiv.org/api/query"
 
@@ -91,13 +90,17 @@ def search(query: str, max_results: int = 20) -> List[Dict[str, Any]]:
     Parameters
     ----------
     query:
-        Search query to run against arXiv's API.  It will be URL encoded
-        and passed as ``search_query=all:<query>``.
+        Search query to run against arXiv's API.  It is sent as
+        ``search_query=all:<query>``.
     max_results:
         Maximum number of results to retrieve (default 20).
     """
+    # httpx will handle URL encoding of the query parameters for us, so we
+    # pass the raw query string directly.  This allows multi-word searches or
+    # queries containing punctuation to work correctly without being
+    # double-encoded.
     params = {
-        "search_query": f"all:{quote_plus(query)}",
+        "search_query": f"all:{query}",
         "start": 0,
         "max_results": max_results,
     }

--- a/backend/tests/test_arxiv.py
+++ b/backend/tests/test_arxiv.py
@@ -57,3 +57,23 @@ def test_search_endpoint(monkeypatch):
     data = r.json()
     assert data["count"] == 1
     assert data["results"][0]["id"] == "1234.5678v1"
+
+
+def test_search_multi_word(monkeypatch):
+    captured = {}
+
+    def fake(url, params=None, timeout=None):
+        captured["params"] = params
+        class R:
+            status_code = 200
+            text = SAMPLE_FEED
+
+            def raise_for_status(self):
+                pass
+
+        return R()
+
+    monkeypatch.setattr(httpx, "get", fake)
+    res = arxiv.search("quantum gravity")
+    assert len(res) == 1
+    assert captured["params"]["search_query"] == "all:quantum gravity"


### PR DESCRIPTION
## Summary
- allow arXiv service to accept multi-word queries by letting httpx handle URL encoding
- add regression test covering multi-word searches

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa65970574832bb4b3591233f9e37c