### PR TITLE
Remove summary heading from generated article

### DIFF
--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -369,7 +369,6 @@ export default function Summarize() {
               ref={summaryRef}
               className="rounded-2xl border border-white/10 bg-neutral-950/60 p-6 leading-relaxed"
             >
-              <h2 className="font-heading text-2xl mb-3 text-white">Summary</h2>
               <div
                 className="text-neutral-200 whitespace-pre-wrap"
                 dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- remove "Summary" heading so author details appear at top of generated article

## Testing
- `pytest backend`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6dd90928832b8934022e4fdf28c0