### PR TITLE
Adjust sidebar width and reposition user icon

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import ClientToaster from "@/components/ClientToaster";
 import AboutHomeLink from "@/components/AboutHomeLink";
-import UserFab from "@/components/UserFab";
 import { Bebas_Neue, Inter } from "next/font/google";
 
 const heading = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-heading" });
@@ -47,12 +46,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <body>
           <AboutHomeLink />
           {children}
-          <div className="fixed bottom-0 left-0 flex flex-col items-center p-4 gap-2">
-            <UserFab />
-            <p className="text-center text-xs text-neutral-400">
-              AI can make mistakes. LayScience is still in test.
-            </p>
-          </div>
           <ClientToaster />
         </body>
       </html>

--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import toast from "react-hot-toast";
 import { startJob, getJob, getSummary } from "@/lib/api";
 import ArxivSearch from "@/components/ArxivSearch";
+import UserFab from "@/components/UserFab";
 
 type HistoryItem = {
   type: "link" | "pdf";
@@ -182,49 +183,59 @@ export default function Summarize() {
 
   return (
     <main className="min-h-dvh flex bg-neutral-950 text-neutral-100">
-      {history.length > 0 && (
-        <aside className="w-full max-w-sm max-h-dvh overflow-y-auto border-r border-neutral-800 p-4 text-sm text-neutral-400">
+      <aside className="w-full max-w-xs max-h-dvh border-r border-neutral-800 p-4 text-sm text-neutral-400 flex flex-col">
+        <div className="flex-1 overflow-y-auto">
           <p className="mb-2">Recent references:</p>
-          <ul className="space-y-1">
-            {history.map((h, i) => (
-              <li key={i}>
-                {h.type === "pdf" ? (
-                  <a
-                    href={h.value}
-                    target="_blank"
-                    rel="noopener"
-                    className="text-neutral-400 hover:underline block truncate"
-                  >
-                    {h.title || h.name || "PDF"}
-                  </a>
-                ) : (
-                  <a
-                    href={
-                      h.value.startsWith("http")
-                        ? h.value
-                        : `https://doi.org/${h.value}`
-                    }
-                    target="_blank"
-                    rel="noopener"
-                    className="text-neutral-400 hover:underline block truncate"
-                    draggable
-                    onDragStart={(e) => {
-                      // Provide both plain text and URI formats for drop targets
-                      e.dataTransfer.setData("text/plain", h.value);
-                      const url = h.value.startsWith("http")
-                        ? h.value
-                        : `https://doi.org/${h.value}`;
-                      e.dataTransfer.setData("text/uri-list", url);
-                    }}
-                  >
-                    {h.title || h.value}
-                  </a>
-                )}
-              </li>
-            ))}
-          </ul>
-        </aside>
-      )}
+          {history.length > 0 ? (
+            <ul className="space-y-1">
+              {history.map((h, i) => (
+                <li key={i}>
+                  {h.type === "pdf" ? (
+                    <a
+                      href={h.value}
+                      target="_blank"
+                      rel="noopener"
+                      className="text-neutral-400 hover:underline block truncate"
+                    >
+                      {h.title || h.name || "PDF"}
+                    </a>
+                  ) : (
+                    <a
+                      href={
+                        h.value.startsWith("http")
+                          ? h.value
+                          : `https://doi.org/${h.value}`
+                      }
+                      target="_blank"
+                      rel="noopener"
+                      className="text-neutral-400 hover:underline block truncate"
+                      draggable
+                      onDragStart={(e) => {
+                        // Provide both plain text and URI formats for drop targets
+                        e.dataTransfer.setData("text/plain", h.value);
+                        const url = h.value.startsWith("http")
+                          ? h.value
+                          : `https://doi.org/${h.value}`;
+                        e.dataTransfer.setData("text/uri-list", url);
+                      }}
+                    >
+                      {h.title || h.value}
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-neutral-500">No recent references.</p>
+          )}
+        </div>
+        <div className="mt-4 flex flex-col items-start gap-2">
+          <UserFab />
+          <p className="text-xs text-neutral-500">
+            AI can make mistakes. LayScience is still in test.
+          </p>
+        </div>
+      </aside>
       <div className="flex-1 flex flex-col">
         <section className="flex-1 flex flex-col items-center justify-center px-6 text-center">
           <h1 className="font-heading text-4xl sm:text-5xl mb-2">Lay Science</h1>


### PR DESCRIPTION
## Summary
- Narrow the sidebar width for a sleeker layout
- Move the user circle into the sidebar's lower-left corner with a disclaimer beneath
- Simplify root layout by removing the floating user button

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6e986b54832b8393cd0ad1b687b6