### PR TITLE
Add recent summaries to sidebar and remove user panel tab

### DIFF
--- a/frontend/components/UserPanel.tsx
+++ b/frontend/components/UserPanel.tsx
@@ -8,14 +8,6 @@ interface Props {
   user: { username?: string; email?: string };
 }
 
-function SummariesTab() {
-  return (
-    <div className="space-y-2">
-      <p className="text-sm text-neutral-300">Your recent summaries will appear here.</p>
-    </div>
-  );
-}
-
 function AccountTab({ user, onDelete }: { user: { username?: string; email?: string }; onDelete: () => void }) {
   return (
     <div className="space-y-4 text-sm">
@@ -33,9 +25,9 @@ function AccountTab({ user, onDelete }: { user: { username?: string; email?: str
 }
 
 export default function UserPanel({ onClose, user }: Props) {
-  const tabs = ["Summaries", "Feedback", "Account"] as const;
+  const tabs = ["Feedback", "Account"] as const;
   type Tab = (typeof tabs)[number];
-  const [tab, setTab] = useState<Tab>("Summaries");
+  const [tab, setTab] = useState<Tab>("Feedback");
 
   return (
     <div
@@ -60,7 +52,6 @@ export default function UserPanel({ onClose, user }: Props) {
           ))}
         </div>
         <div className="p-4 max-h-80 overflow-y-auto">
-          {tab === "Summaries" && <SummariesTab />}
           {tab === "Feedback" && <FeedbackTab />}
           {tab === "Account" && <AccountTab user={user} onDelete={() => {}} />}
         </div>


### PR DESCRIPTION
## Summary
- store generated summaries in localStorage and list them in a new sidebar section
- split sidebar into references and summaries sections
- drop unused summaries tab from user panel

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa77fda3f0832b80d6fa752e4116e2