### PR TITLE
Reposition user panel and survey submit button

### DIFF
--- a/frontend/components/Feedback/FeedbackTab.tsx
+++ b/frontend/components/Feedback/FeedbackTab.tsx
@@ -70,12 +70,14 @@ export default function FeedbackTab() {
 
       {error && <p className="text-red-400">{error}</p>}
 
-      <button
-        type="submit"
-        className="rounded bg-blue-600/20 px-3 py-2 text-blue-200 hover:bg-blue-600/30"
-      >
-        Submit
-      </button>
+      <div className="text-right">
+        <button
+          type="submit"
+          className="rounded bg-blue-600/20 px-3 py-2 text-blue-200 hover:bg-blue-600/30"
+        >
+          Submit
+        </button>
+      </div>
     </form>
   );
 }

--- a/frontend/components/UserFab.tsx
+++ b/frontend/components/UserFab.tsx
@@ -31,7 +31,7 @@ export default function UserFab() {
   }
 
   return (
-    <>
+    <div className="relative">
       <button
         type="button"
         onClick={() => setOpen(true)}
@@ -39,8 +39,15 @@ export default function UserFab() {
       >
         {getInitials(user)}
       </button>
-      {open && <UserPanel onClose={() => setOpen(false)} user={user} />}
-    </>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/30" onClick={() => setOpen(false)} />
+          <div className="absolute left-full ml-2 top-0 z-50">
+            <UserPanel user={user} />
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/frontend/components/UserPanel.tsx
+++ b/frontend/components/UserPanel.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import FeedbackTab from "./Feedback/FeedbackTab";
 
 interface Props {
-  onClose: () => void;
   user: { username?: string; email?: string };
 }
 
@@ -32,38 +31,30 @@ function AccountTab({ user, onDelete }: { user: { username?: string; email?: str
   );
 }
 
-export default function UserPanel({ onClose, user }: Props) {
+export default function UserPanel({ user }: Props) {
   const tabs = ["Summaries", "Feedback", "Account"] as const;
   type Tab = (typeof tabs)[number];
   const [tab, setTab] = useState<Tab>("Summaries");
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-start bg-black/30 px-4 pt-14 pb-4"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-xs rounded-lg border border-neutral-700 bg-neutral-900 text-neutral-100 shadow-lg"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex border-b border-neutral-700">
-          {tabs.map((t) => (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={`flex-1 py-2 text-sm font-medium hover:bg-neutral-800 ${
-                tab === t ? "bg-neutral-800" : ""
-              }`}
-            >
-              {t}
-            </button>
-          ))}
-        </div>
-        <div className="p-4 max-h-80 overflow-y-auto">
-          {tab === "Summaries" && <SummariesTab />}
-          {tab === "Feedback" && <FeedbackTab />}
-          {tab === "Account" && <AccountTab user={user} onDelete={() => {}} />}
-        </div>
+    <div className="w-full max-w-xs rounded-lg border border-neutral-700 bg-neutral-900 text-neutral-100 shadow-lg">
+      <div className="flex border-b border-neutral-700">
+        {tabs.map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`flex-1 py-2 text-sm font-medium hover:bg-neutral-800 ${
+              tab === t ? "bg-neutral-800" : ""
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="p-4 max-h-80 overflow-y-auto">
+        {tab === "Summaries" && <SummariesTab />}
+        {tab === "Feedback" && <FeedbackTab />}
+        {tab === "Account" && <AccountTab user={user} onDelete={() => {}} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Anchor the user panel to the account button so it appears beside it rather than over the sidebar.
- Align the survey's submit button to the right for a cleaner layout.

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa788f00f0832b8e39057304e4d648