### PR TITLE
Improve arXiv search UI and result count

### DIFF
--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -635,7 +635,7 @@ def get_summary(job_id: str):
 
 
 @app.get("/api/v1/arxiv/search", tags=["arxiv"])
-def arxiv_search(q: str, max_results: int = 20):
+def arxiv_search(q: str, max_results: int = 50):
     """Search arXiv by title/keywords.
 
     Returns a JSON object with the original query, number of results and the

--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -446,56 +446,62 @@ export default function Summarize() {
               <div className="mt-4">
                 {busy && <p className="text-center text-neutral-500">Searching...</p>}
                 {arxivResults.length > 0 ? (
-                  <ul className="max-h-96 overflow-y-auto space-y-2">
-                    {arxivResults.map((r) => (
-                      <li
-                        key={r.id}
-                        className="flex items-start justify-between gap-2"
-                      >
-                        <a
-                          href={r.links?.html || `https://arxiv.org/abs/${r.id}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="flex-1 text-neutral-200 hover:underline break-words"
+                  <div>
+                    <div className="flex items-center justify-between text-sm text-neutral-400 px-1 mb-2">
+                      <span>Search Results</span>
+                      <span>Summrize</span>
+                    </div>
+                    <ul className="max-h-96 overflow-y-auto space-y-2">
+                      {arxivResults.map((r) => (
+                        <li
+                          key={r.id}
+                          className="flex items-start justify-between gap-2"
                         >
-                          {r.title}
-                        </a>
-                        <button
-                          onClick={() =>
-                            handleArxivSelect(
-                              r.links?.pdf ||
-                                r.links?.html ||
-                                `https://arxiv.org/abs/${r.id}`
-                            )
-                          }
-                          className="text-neutral-400 hover:text-white"
-                          aria-label="Summarize paper"
-                        >
-                          <svg
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            className="h-4 w-4"
+                          <a
+                            href={r.links?.html || `https://arxiv.org/abs/${r.id}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex-1 text-neutral-200 hover:underline break-words"
                           >
-                            <rect
-                              x="3"
-                              y="4"
-                              width="18"
-                              height="16"
-                              rx="2"
-                              stroke="currentColor"
-                              strokeWidth="1.5"
-                            />
-                            <path
-                              stroke="currentColor"
-                              strokeWidth="1.5"
-                              strokeLinecap="round"
-                              d="M8 8h8M8 12h8M8 16h5"
-                            />
-                          </svg>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
+                            {r.title.replace(/\$/g, "")}
+                          </a>
+                          <button
+                            onClick={() =>
+                              handleArxivSelect(
+                                r.links?.pdf ||
+                                  r.links?.html ||
+                                  `https://arxiv.org/abs/${r.id}`
+                              )
+                            }
+                            className="text-neutral-400 hover:text-white"
+                            aria-label="Summarize paper"
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              className="h-4 w-4"
+                            >
+                              <rect
+                                x="3"
+                                y="4"
+                                width="18"
+                                height="16"
+                                rx="2"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                              />
+                              <path
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                d="M8 8h8M8 12h8M8 16h5"
+                              />
+                            </svg>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 ) : ref && !busy ? (
                   <p className="text-center text-neutral-500">No results</p>
                 ) : null}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -94,7 +94,7 @@ export async function getSummary(id: string) {
   return asJson(res);
 }
 
-export async function searchArxiv(query: string, maxResults = 20) {
+export async function searchArxiv(query: string, maxResults = 50) {
   const res = await fetch(
     api(`/api/v1/arxiv/search?q=${encodeURIComponent(query)}&max_results=${maxResults}`),
     { cache: "no-store" }


### PR DESCRIPTION
## Summary
- strip LaTeX `$` delimiters from arXiv titles for cleaner display
- raise default arXiv search result limit to 50
- add "Search Results" heading with "Summrize" column label and sanitize titles in UI

## Testing
- `pytest`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7abd2844832b88d0ba70b13fd4f3