### PR TITLE
Fix missing onClose prop in UserPanel usage

### DIFF
--- a/frontend/components/UserFab.tsx
+++ b/frontend/components/UserFab.tsx
@@ -40,12 +40,7 @@ export default function UserFab() {
         {getInitials(user)}
       </button>
       {open && (
-        <>
-          <div className="fixed inset-0 z-40 bg-black/30" onClick={() => setOpen(false)} />
-          <div className="absolute left-full ml-2 top-0 z-50">
-            <UserPanel user={user} />
-          </div>
-        </>
+        <UserPanel user={user} onClose={() => setOpen(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- pass onClose handler when rendering UserPanel from UserFab
- drop redundant wrapper and overlay in UserFab

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7c21dd18832bb9c00653e9ddadcf