### PR TITLE
Fix About page navigation

### DIFF
--- a/frontend/__tests__/aboutHomeLink.test.tsx
+++ b/frontend/__tests__/aboutHomeLink.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import AboutHomeLink from "@/components/AboutHomeLink";
+import { usePathname } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+const mockedUsePathname = usePathname as jest.Mock;
+
+describe("AboutHomeLink", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("links to about from summarize page", () => {
+    mockedUsePathname.mockReturnValue("/summarize");
+    render(<AboutHomeLink />);
+    const link = screen.getByRole("link", { name: /about/i });
+    expect(link).toHaveAttribute("href", "/about");
+  });
+
+  it("links home to summarize when account exists", async () => {
+    mockedUsePathname.mockReturnValue("/about");
+    localStorage.setItem("hasAccount", "true");
+    render(<AboutHomeLink />);
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /home/i });
+      expect(link).toHaveAttribute("href", "/summarize");
+    });
+  });
+
+  it("links home to landing when no account", async () => {
+    mockedUsePathname.mockReturnValue("/about");
+    render(<AboutHomeLink />);
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /home/i });
+      expect(link).toHaveAttribute("href", "/");
+    });
+  });
+});

--- a/frontend/components/AboutHomeLink.tsx
+++ b/frontend/components/AboutHomeLink.tsx
@@ -2,15 +2,26 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function AboutHomeLink() {
   const pathname = usePathname();
   const isAbout = pathname?.startsWith("/about");
+  const [hasAccount, setHasAccount] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setHasAccount(localStorage.getItem("hasAccount") === "true");
+    }
+  }, []);
+
+  const href = isAbout ? (hasAccount ? "/summarize" : "/") : "/about";
 
   return (
     <Link
-      href={isAbout ? "/" : "/about"}
-      className="fixed top-2 right-2 text-xs text-neutral-400 hover:text-neutral-200"
+      href={href}
+      prefetch={false}
+      className="fixed top-2 right-2 z-50 text-xs text-neutral-400 hover:text-neutral-200"
     >
       {isAbout ? "home" : "about"}
     </Link>


### PR DESCRIPTION
## Summary
- Ensure About link works from summarize page and Home on About page routes correctly depending on account
- Add test coverage for about/home navigation

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7fb50ff0832bb36c3a29b55ff9e0