### PR TITLE
Ensure unique, scrollable recent summaries

### DIFF
--- a/frontend/__tests__/summaries.test.tsx
+++ b/frontend/__tests__/summaries.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Summarize from '../components/Summarize';
+
+describe('Recent summaries sidebar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('deduplicates summaries from storage', () => {
+    const dupes = [
+      { id: '1', title: 'Title', content: 'A' },
+      { id: '1', title: 'Title', content: 'A' },
+    ];
+    localStorage.setItem('summaries', JSON.stringify(dupes));
+    render(<Summarize />);
+    expect(screen.getAllByRole('button', { name: 'Title' })).toHaveLength(1);
+  });
+
+  it('allows deleting a summary', () => {
+    const data = [{ id: '1', title: 'Title', content: 'A' }];
+    localStorage.setItem('summaries', JSON.stringify(data));
+    render(<Summarize />);
+    fireEvent.click(screen.getByRole('button', { name: /delete summary/i }));
+    expect(screen.queryByRole('button', { name: 'Title' })).not.toBeInTheDocument();
+    expect(localStorage.getItem('summaries')).toBe('[]');
+  });
+});


### PR DESCRIPTION
## Summary
- Deduplicate stored summaries and clean up duplicates on load
- Add sidebar controls to remove summaries and restrict list height with scrolling
- Cover summary dedupe and deletion behavior with tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - cannot access registry)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8e8ae104832bb6a9b3bcbbbc6e4c