### PR TITLE
feat: add account deletion handler

### DIFF
--- a/frontend/__tests__/userPanel.test.tsx
+++ b/frontend/__tests__/userPanel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import UserPanel from "@/components/UserPanel";
+import { deleteAccount } from "@/lib/api";
+
+jest.mock("@/lib/api", () => ({
+  deleteAccount: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedDeleteAccount = deleteAccount as jest.MockedFunction<typeof deleteAccount>;
+
+describe("UserPanel delete account", () => {
+  beforeEach(() => {
+    localStorage.setItem("username", "user");
+    localStorage.setItem("email", "user@example.com");
+    localStorage.setItem("hasAccount", "true");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("calls API and clears localStorage", async () => {
+    mockedDeleteAccount.mockResolvedValueOnce({});
+    const onClose = jest.fn();
+    render(<UserPanel user={{ username: "user", email: "user@example.com" }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => expect(mockedDeleteAccount).toHaveBeenCalled());
+
+    expect(localStorage.getItem("username")).toBeNull();
+    expect(localStorage.getItem("email")).toBeNull();
+    expect(localStorage.getItem("hasAccount")).toBeNull();
+  });
+});
+

--- a/frontend/components/UserPanel.tsx
+++ b/frontend/components/UserPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import toast from "react-hot-toast";
+import { deleteAccount } from "@/lib/api";
 import FeedbackTab from "./Feedback/FeedbackTab";
 
 interface Props {
@@ -29,6 +31,19 @@ export default function UserPanel({ onClose, user }: Props) {
   type Tab = (typeof tabs)[number];
   const [tab, setTab] = useState<Tab>("Feedback");
 
+  async function handleDelete() {
+    try {
+      await deleteAccount();
+      localStorage.removeItem("username");
+      localStorage.removeItem("email");
+      localStorage.removeItem("hasAccount");
+      toast.success("Account deleted");
+      onClose();
+    } catch (e: any) {
+      toast.error(e.message || "Failed to delete account");
+    }
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-start bg-black/30 px-4 pt-14 pb-4"
@@ -51,7 +66,7 @@ export default function UserPanel({ onClose, user }: Props) {
         </div>
         <div className="p-4 max-h-80 overflow-y-auto">
           {tab === "Feedback" && <FeedbackTab />}
-          {tab === "Account" && <AccountTab user={user} onDelete={() => {}} />}
+          {tab === "Account" && <AccountTab user={user} onDelete={handleDelete} />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- call the new account deletion endpoint from the user panel and clear local storage on success
- add a Jest test ensuring account deletion triggers the API call and clears stored user data

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68aa96eb0170832b8d30c3ddbaec92d3