### PR TITLE
Enhance verification email content

### DIFF
--- a/backend/tests/test_registration.py
+++ b/backend/tests/test_registration.py
@@ -37,7 +37,8 @@ def test_register_sends_email(monkeypatch):
 
         def send_message(self, msg):
             captured["to"] = msg["To"]
-            captured["body"] = msg.get_content()
+            body = msg.get_body(preferencelist=("plain", "html"))
+            captured["body"] = body.get_content() if body else ""
 
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     # Intentionally do not set SMTP_PORT to rely on default 587


### PR DESCRIPTION
## Summary
- include logo and welcome message in verification emails with HTML support
- adjust registration test for multipart emails and add admin users endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab1ecc916c832ba3922587bd6e400a