### PR TITLE
Add API rewrite rule to Next.js configuration

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { typedRoutes: true }
+  experimental: { typedRoutes: true },
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "https://layscience.onrender.com/api/:path*",
+      },
+    ];
+  },
 };
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Forward `/api/*` requests from the Next.js app to the Render backend via a rewrite rule.

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2a325a00832b9c012f479a171603