### PR TITLE
fix: show logo in verification email

### DIFF
--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -117,7 +117,7 @@ pending_codes: Dict[str, Dict[str, Any]] = _load_json(PENDING_PATH)
 
 def _send_verification_email(to: str, code: str) -> None:
     app_name = os.getenv("APP_NAME", "LayScience")
-    logo_url = os.getenv("APP_LOGO_URL", "https://layscience.ai/logo.png")
+    logo_url = os.getenv("APP_LOGO_URL", "https://layscience.ai/icon.png")
     mail_api_key = os.getenv("MAIL_API_KEY")
     if mail_api_key:
         from_email = os.getenv("MAIL_FROM", "no-reply@mail.layscience.ai")

--- a/backend/tests/test_registration.py
+++ b/backend/tests/test_registration.py
@@ -39,6 +39,8 @@ def test_register_sends_email(monkeypatch):
             captured["to"] = msg["To"]
             body = msg.get_body(preferencelist=("plain", "html"))
             captured["body"] = body.get_content() if body else ""
+            html = msg.get_body(preferencelist=("html",))
+            captured["html"] = html.get_content() if html else ""
 
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
     # Intentionally do not set SMTP_PORT to rely on default 587
@@ -56,3 +58,4 @@ def test_register_sends_email(monkeypatch):
     assert captured["port"] == 587
     assert captured["to"] == "alice@example.com"
     assert "verification code" in captured["body"].lower()
+    assert "icon.png" in captured["html"]


### PR DESCRIPTION
## Summary
- ensure verification email logo points to existing icon
- test registration email HTML includes the logo

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2bcc13d4832b8659f208d7ba906f