### PR TITLE
Improve loading feedback in summarize UI

### DIFF
--- a/frontend/components/LoadingMessage.tsx
+++ b/frontend/components/LoadingMessage.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+export default function LoadingMessage({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 text-center text-neutral-500">
+      <svg
+        className="h-4 w-4 animate-spin text-neutral-400"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      <span>{message}</span>
+    </div>
+  );
+}
+

--- a/frontend/components/Summarize.tsx
+++ b/frontend/components/Summarize.tsx
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import { startJob, getJob, getSummary, searchArxiv } from "@/lib/api";
 // ArXiv search is now integrated directly into this component
 import UserFab from "@/components/UserFab";
+import LoadingMessage from "@/components/LoadingMessage";
 
 type HistoryItem = {
   type: "link" | "pdf";
@@ -505,7 +506,9 @@ export default function Summarize() {
           <section className="mx-auto w-full max-w-4xl px-6 pb-16">
             {showArxiv ? (
               <div className="mt-4">
-                {busy && <p className="text-center text-neutral-500">Searching...</p>}
+                {busy && (
+                  <LoadingMessage message="Searching for relevant papers..." />
+                )}
                 {arxivResults.length > 0 ? (
                   <div>
                     <div className="flex items-center justify-between text-sm text-neutral-400 px-1 mb-2">
@@ -582,7 +585,7 @@ export default function Summarize() {
                 />
               </article>
             ) : status === "running" || status === "queued" ? (
-              <p className="text-center text-neutral-500">Generating summary...</p>
+              <LoadingMessage message="Preparing your summary. Please wait..." />
             ) : null}
           </section>
       </div>


### PR DESCRIPTION
## Summary
- add reusable `LoadingMessage` with spinner
- display friendly progress text when searching and preparing summaries

## Testing
- `pytest`
- `npm test` *(fails: jest: not found; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c3985f0832bbf7aeff90f9744fd