### PR TITLE
fix: show background video

### DIFF
--- a/frontend/components/Welcome.tsx
+++ b/frontend/components/Welcome.tsx
@@ -52,7 +52,7 @@ export default function Welcome() {
         muted
         playsInline
         poster="/gif.gif"
-        className="absolute inset-0 w-full h-full object-cover opacity-40 -z-10"
+        className="absolute inset-0 w-full h-full object-cover opacity-40 pointer-events-none"
       />
       <Image src="/icon.png" alt="Lay Science logo" width={96} height={96} className="mb-4 opacity-80" />
       <h1 className="font-heading text-4xl sm:text-5xl md:text-6xl mb-6">Lay Science</h1>


### PR DESCRIPTION
## Summary
- fix background video not showing by removing negative z-index and disabling pointer events

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)
- `npm test` (fails: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68ab2ccab4fc832bbd7afefc73ee4868