### PR TITLE
Dim welcome page background video

### DIFF
--- a/frontend/components/Welcome.tsx
+++ b/frontend/components/Welcome.tsx
@@ -52,7 +52,7 @@ export default function Welcome() {
         muted
         playsInline
         poster="/gif.gif"
-        className="absolute inset-0 w-full h-full object-cover opacity-40 pointer-events-none"
+        className="absolute inset-0 w-full h-full object-cover opacity-10 pointer-events-none"
       />
       <Image src="/icon.png" alt="Lay Science logo" width={96} height={96} className="mb-4 opacity-80" />
       <h1 className="font-heading text-4xl sm:text-5xl md:text-6xl mb-6">Lay Science</h1>


### PR DESCRIPTION
## Summary
- further dim welcome page background video by reducing opacity to 10%

## Testing
- `npm install` *(fails: 403 Forbidden - GET @testing-library/jest-dom)*
- `npm test` *(fails: jest: not found)*
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68ab77a26380832ba753f6e66e0c6c0c