### PR TITLE
Handle database init failures by falling back to JSON storage

### DIFF
--- a/backend/tests/test_accounts_db_fallback.py
+++ b/backend/tests/test_accounts_db_fallback.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import backend.server.main as main_module
+from backend.server.services import accounts_db
+
+
+def test_accounts_db_init_failure_falls_back(monkeypatch, tmp_path):
+    """If the PostgreSQL connection fails we fall back to JSON storage."""
+    # Start from a clean environment/state.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    accounts_db.engine = None
+    importlib.reload(main_module)
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/db")
+
+    calls = {}
+
+    def failing_init():
+        calls["init"] = True
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(accounts_db, "init", failing_init)
+
+    reloaded = importlib.reload(main_module)
+
+    assert calls.get("init") is True
+    assert reloaded.DATABASE_URL is None
+    assert reloaded.accounts == {}
+    assert reloaded.pending_codes == {}
+
+    # Clean up by restoring environment and module state for subsequent tests.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    accounts_db.engine = None
+    importlib.reload(main_module)


### PR DESCRIPTION
## Summary
- fall back to the JSON-backed account store when the DATABASE_URL connection fails at startup
- log the failure so deployments show the root cause instead of crashing
- add a regression test that forces the database initialisation error and asserts the fallback behaviour

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d336a34e28832ba8185b2d305fc5c6